### PR TITLE
[chore] Set up GitHub Issues workflow (#1)

### DIFF
--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,0 +1,35 @@
+---
+name: Feature / Change
+about: Describe a planned feature or change with clear scope
+title: "[type] "
+labels: ''
+assignees: ''
+---
+
+## What
+
+<!-- One paragraph: what this issue adds, changes, or fixes -->
+
+## Why
+
+<!-- One sentence: the motivation or problem being solved -->
+
+## Scope
+
+<!-- Bulleted list of what IS in scope -->
+-
+
+## Out of Scope
+
+<!-- Bulleted list of what is explicitly NOT in this issue -->
+-
+
+## Acceptance Criteria
+
+<!-- How will we know this is done? -->
+- [ ]
+
+## Related
+
+<!-- Links to design spec, ADR, plan, or other issues -->
+- Spec: `docs/superpowers/specs/YYYY-MM-DD-*.md`

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,22 @@
+## Summary
+
+<!-- 2-3 sentences describing what this PR does -->
+
+## Changes
+
+<!-- Bulleted list of the meaningful changes -->
+-
+
+## Test Evidence
+
+- [ ] `mvn test` — all N tests pass
+- [ ] `mvn compile` — no errors
+- [ ] Manual smoke test (describe briefly if applicable)
+
+## Closes
+
+closes #ISSUE_NUMBER
+
+## Notes for Reviewer
+
+<!-- Anything non-obvious, trade-offs made, follow-up issues opened -->

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -70,7 +70,7 @@ target/generated-sources/ Generated Spring interfaces + POJOs — do not edit
 All code changes are tracked via GitHub Issues and merged via pull requests. Never commit directly to `main`. See [`docs/GITHUB-WORKFLOW.md`](docs/GITHUB-WORKFLOW.md) for the full process.
 
 Quick reference:
-- Branch pattern: `feature/{issue-number}-{kebab-description}`
+- Branch pattern: `{prefix}/{issue-number}-{kebab-description}` where `prefix` ∈ {`feature`, `fix`, `docs`, `chore`, `refactor`, `test`}
 - Commit format: `type: description (#N)`
 - PR closes issue via: `closes #N` in PR body
 - Before starting work: verify or create a GitHub issue

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,7 +27,7 @@ export CORS_ORIGINS=http://localhost:5173
 
 ## API-First Workflow
 
-- **Specs live in `src/main/resources/api/`** — one YAML file per domain (e.g. `visitor-session-api.yaml`, `chat-api.yaml`)
+- **Specs live in `src/main/resources/api/`** — one YAML file per domain (e.g. `visitor-session-api.yaml`, `ai-chat-api.yaml`)
 - **Codegen via `openapi-generator-maven-plugin`** — generates Spring interfaces + delegate pattern into `target/generated-sources`; never edit generated files directly
 - **Generated models are POJOs** (Lombok-annotated) — not Java records; this is intentional for codegen compatibility
 - **Hand-written records** are still used for internal non-API data structures where appropriate

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -21,7 +21,7 @@ export CORS_ORIGINS=http://localhost:5173
 
 - **Java 21** — use sealed interfaces, pattern matching where appropriate
 - **Constructor injection** — never `@Autowired` on fields
-- **Lombok only on JPA entities** — `@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder`
+- **Lombok only on hand-written JPA entities** — `@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder`; generated API models also use Lombok (via codegen) — this is intentional and not subject to this restriction
 - **`@Transactional` on service write methods** — not on controllers
 - **Instant not LocalDateTime** — all timestamps UTC, mapped to `TIMESTAMPTZ`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -19,17 +19,26 @@ export CORS_ORIGINS=http://localhost:5173
 
 ## Code Conventions
 
-- **Java 21** — use records, sealed interfaces, pattern matching where appropriate
+- **Java 21** — use sealed interfaces, pattern matching where appropriate
 - **Constructor injection** — never `@Autowired` on fields
-- **No Lombok on records** — use Java records for DTOs
 - **Lombok only on JPA entities** — `@Getter @Setter @NoArgsConstructor @AllArgsConstructor @Builder`
 - **`@Transactional` on service write methods** — not on controllers
 - **Instant not LocalDateTime** — all timestamps UTC, mapped to `TIMESTAMPTZ`
 
+## API-First Workflow
+
+- **Specs live in `src/main/resources/api/`** — one YAML file per domain (e.g. `visitor-session-api.yaml`, `chat-api.yaml`)
+- **Codegen via `openapi-generator-maven-plugin`** — generates Spring interfaces + delegate pattern into `target/generated-sources`; never edit generated files directly
+- **Generated models are POJOs** (Lombok-annotated) — not Java records; this is intentional for codegen compatibility
+- **Hand-written records** are still used for internal non-API data structures where appropriate
+- **Delegate pattern** — implement the generated `*ApiDelegate` interface in `api/`; the generated controller wires it automatically
+- **New domains start spec-first** — write the OpenAPI YAML before writing any controller code
+- **Existing Phase 1 controllers** were written code-first; specs were reverse-engineered from them as a one-time migration
+
 ## Package Conventions
 
 ```
-api/        REST controllers + inline record DTOs
+api/        ApiDelegate implementations (business-facing API layer)
 service/    Business logic, orchestration
 domain/
   entity/   JPA entities only
@@ -37,6 +46,8 @@ domain/
 ai/         Anthropic/Spring AI integration
 config/     Spring configuration beans
 infra/      External integrations (auth, email) — stub for now
+src/main/resources/api/   OpenAPI 3 spec files (one per domain)
+target/generated-sources/ Generated Spring interfaces + POJOs — do not edit
 ```
 
 ## Schema Rules
@@ -53,3 +64,14 @@ infra/      External integrations (auth, email) — stub for now
 - Do not use `spring.jpa.hibernate.ddl-auto=create` or `update`
 - Do not store secrets in any tracked file
 - Do not add Docker to the Spring Boot build — the app runs on host, only Postgres in Docker
+
+## Git Workflow
+
+All code changes are tracked via GitHub Issues and merged via pull requests. Never commit directly to `main`. See [`docs/GITHUB-WORKFLOW.md`](docs/GITHUB-WORKFLOW.md) for the full process.
+
+Quick reference:
+- Branch pattern: `feature/{issue-number}-{kebab-description}`
+- Commit format: `type: description (#N)`
+- PR closes issue via: `closes #N` in PR body
+- Before starting work: verify or create a GitHub issue
+- After completing work: open a PR, or push branch + post progress comment on issue

--- a/docs/GITHUB-WORKFLOW.md
+++ b/docs/GITHUB-WORKFLOW.md
@@ -1,0 +1,146 @@
+# GitHub Issues Workflow
+
+Every change to this repository — planned feature or reactive fix — is tracked with a GitHub Issue. Issues are written as features or changes with clear scope. Commits reference issues by number. PRs close issues automatically on merge. No code lands on `main` via a direct commit.
+
+---
+
+## Issue Creation
+
+**When to create an issue:**
+- Before starting any work session that produces commits
+- When a design spec or plan is approved and implementation is about to begin
+- When scope expands mid-session (new issue for new scope — don't widen the current one)
+
+**Title format:** `[type] Short imperative phrase describing the outcome`
+
+| Type | Use for |
+|---|---|
+| `[feat]` | New functionality |
+| `[fix]` | Bug or behavioral correction |
+| `[test]` | Test-only changes |
+| `[docs]` | Documentation, diagrams, ADRs |
+| `[chore]` | Build config, tooling, non-production |
+| `[refactor]` | Restructuring with no behavior change |
+
+**Labels:** Apply one type label + one phase label to every issue.
+
+| Label | Color | Meaning |
+|---|---|---|
+| `feature` | `#0075ca` | New capability |
+| `fix` | `#d73a4a` | Bug or correction |
+| `docs` | `#cfd3d7` | Documentation only |
+| `chore` | `#e4e669` | Build, tooling, config |
+| `refactor` | `#a2eeef` | Restructuring, no behavior change |
+| `phase-1` | `#7057ff` | Phase 1 scope |
+| `phase-2` | `#008672` | Phase 2 scope (deferred) |
+| `in-progress` | `#fbca04` | Actively being worked |
+| `blocked` | `#b60205` | Blocked |
+
+---
+
+## Branch Naming
+
+Pattern: `{type}/{issue-number}-{kebab-case-description}`
+
+| Issue type | Branch prefix |
+|---|---|
+| feat | `feature/` |
+| fix | `fix/` |
+| docs | `docs/` |
+| chore | `chore/` |
+| refactor | `refactor/` |
+| test | `test/` |
+
+Rules:
+- Always branch from `main`: `git checkout -b feature/42-description main`
+- Never commit directly to `main`
+- Delete branch after PR merges
+
+---
+
+## Commit Messages
+
+Format: `type: short description (#issue-number)`
+
+The `(#N)` reference links the commit to the issue on GitHub without closing it — closing happens only via the PR.
+
+```
+feat: add openapi-generator-maven-plugin to pom.xml (#1)
+refactor: extract VisitorSessionDelegate from ChatController (#2)
+docs: add ARCHITECTURE.md with C4 context diagram (#3)
+```
+
+Rules:
+- Type must match the branch type
+- Lowercase, imperative, under 72 characters including the issue reference
+- No `closes` or `fixes` in commit messages — those go only in the PR body
+
+---
+
+## Pull Requests
+
+The PR body's `closes #N` line is the only mechanism that auto-closes the issue on merge.
+
+Use the PR template (`.github/pull_request_template.md`). Fill in:
+- Summary of what the PR does
+- Test evidence (`mvn test` output)
+- `closes #ISSUE_NUMBER`
+
+---
+
+## Issue Lifecycle
+
+| State | Action |
+|---|---|
+| Open | Issue created, work not started |
+| In Progress | Add `in-progress` label; post: "Starting work. Branch: \`feature/N-desc\`" |
+| Progress update | Post comment: "Progress: [done]. Next: [remaining]. Commits: [list]" |
+| PR opened | Post comment: "PR opened: #PR_NUMBER" |
+| Closed | Happens automatically when PR merges — no manual close needed |
+| Blocked | Swap `in-progress` for `blocked`; post comment explaining blocker |
+
+Progress comments are the breadcrumb trail. Post one after each logical chunk of work, especially before ending a session without a PR.
+
+---
+
+## Claude Code Session Protocol
+
+**At session start:**
+1. `git status` + `git log --oneline -5` — understand current state and issue references
+2. `gh issue list --state open` — see active issues
+3. State: "Resuming issue #N on branch `feature/N-desc`" or "Starting fresh"
+
+**Before writing code:**
+1. Confirm a GitHub issue exists for the work
+2. If not: `gh issue create --title "[type] Description" --body "..." --label "feature,phase-1"`
+3. Add label: `gh issue edit N --add-label "in-progress"`
+4. Create branch: `git checkout -b feature/N-description main`
+5. Post start comment on issue
+
+**During work:**
+- Commit frequently with `(#N)` references
+- Post a progress comment after each logical milestone
+
+**When session ends or feature is complete:**
+1. Run `mvn test` — all tests must pass
+2. Post final progress comment on issue
+3. If feature complete: open PR with `closes #N` in body, post PR link on issue
+4. If not complete: commit everything that compiles, push branch, post progress comment
+
+---
+
+## One-Time Setup
+
+Run once to create labels:
+
+```bash
+gh label create "feature"     --color "0075ca" --description "New capability"
+gh label create "fix"         --color "d73a4a" --description "Bug or correction"
+gh label create "docs"        --color "cfd3d7" --description "Documentation only"
+gh label create "chore"       --color "e4e669" --description "Build, tooling, config"
+gh label create "refactor"    --color "a2eeef" --description "Restructuring, no behavior change"
+gh label create "phase-1"     --color "7057ff" --description "Phase 1 scope"
+gh label create "phase-2"     --color "008672" --description "Phase 2 scope (deferred)"
+gh label create "in-progress" --color "fbca04" --description "Actively being worked"
+gh label create "blocked"     --color "b60205" --description "Blocked"
+```

--- a/docs/GITHUB-WORKFLOW.md
+++ b/docs/GITHUB-WORKFLOW.md
@@ -40,7 +40,7 @@ Every change to this repository — planned feature or reactive fix — is track
 
 ## Branch Naming
 
-Pattern: `{type}/{issue-number}-{kebab-case-description}`
+Pattern: `{branch-prefix}/{issue-number}-{kebab-case-description}`
 
 | Issue type | Branch prefix |
 |---|---|
@@ -50,6 +50,8 @@ Pattern: `{type}/{issue-number}-{kebab-case-description}`
 | chore | `chore/` |
 | refactor | `refactor/` |
 | test | `test/` |
+
+Note: the `feat` issue type maps to the `feature/` branch prefix; commit messages use the shorter `feat:` type token.
 
 Rules:
 - Always branch from `main`: `git checkout -b feature/42-description main`
@@ -71,7 +73,7 @@ docs: add ARCHITECTURE.md with C4 context diagram (#3)
 ```
 
 Rules:
-- Type must match the branch type
+- Type must match the issue type (feat/fix/docs/chore/refactor/test)
 - Lowercase, imperative, under 72 characters including the issue reference
 - No `closes` or `fixes` in commit messages — those go only in the PR body
 

--- a/docs/superpowers/plans/2026-03-31-code-review-fixes.md
+++ b/docs/superpowers/plans/2026-03-31-code-review-fixes.md
@@ -1,0 +1,459 @@
+# Code Review Fixes Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Fix 5 bugs identified in peer code review: missing HTTP endpoint for addMessage, updatedAt not bumped on new messages, @Transactional no-op on streamChat, missing global exception handler for IllegalArgumentException, and missing @NotNull on visitorId fields.
+
+**Architecture:** Fixes are self-contained: one service mutation (updatedAt), one annotation removal (streamChat), one new file (GlobalExceptionHandler), two annotation additions (@NotNull), and one new controller endpoint (addMessage). All follow existing patterns — no new beans, no schema changes.
+
+**Tech Stack:** Java 21, Spring Boot, Spring MVC, Jakarta Validation, Mockito/JUnit 5, MockMvc (@WebMvcTest)
+
+---
+
+## File Map
+
+| Fix | Files Modified | Files Created |
+|-----|----------------|---------------|
+| 2 | `service/MessageService.java`, `test/.../MessageServiceTest.java` | — |
+| 3 | `ai/PlannerAiService.java` | — |
+| 4 | `test/.../MessageControllerTest.java`, `test/.../ChatControllerTest.java` | `api/GlobalExceptionHandler.java` |
+| 5 | `api/MessageController.java`, `api/ChatController.java`, `test/.../MessageControllerTest.java`, `test/.../ChatControllerTest.java` | — |
+| 1 | `api/MessageController.java`, `test/.../MessageControllerTest.java` | — |
+
+---
+
+### Task 1: Fix updatedAt Not Bumped in addMessage
+
+**Files:**
+- Modify: `src/test/java/com/advisorplatform/service/MessageServiceTest.java`
+- Modify: `src/main/java/com/advisorplatform/service/MessageService.java`
+
+- [ ] **Step 1: Add failing assertion to the existing addMessage test**
+
+  Open `src/test/java/com/advisorplatform/service/MessageServiceTest.java`.
+
+  Replace the existing `addMessage_knownThread_savesVisitorMessageAndBumpsThread` test with this version that also pins `updatedAt` and asserts it was bumped:
+
+  ```java
+  @Test
+  void addMessage_knownThread_savesVisitorMessageAndBumpsThread() {
+      UUID threadId = UUID.randomUUID();
+      MessageThread thread = MessageThread.builder().build();
+      Instant oldTime = Instant.parse("2020-01-01T00:00:00Z");
+      thread.setUpdatedAt(oldTime); // pin to a known past value so we can detect the bump
+      when(threadRepo.findById(threadId)).thenReturn(Optional.of(thread));
+      ThreadMessage saved = ThreadMessage.builder()
+              .thread(thread).senderRole("visitor").content("More info").build();
+      when(messageRepo.save(any(ThreadMessage.class))).thenReturn(saved);
+      when(threadRepo.save(thread)).thenReturn(thread);
+
+      ThreadMessage result = messageService.addMessage(threadId, "More info");
+
+      assertThat(result).isSameAs(saved);
+      verify(messageRepo).save(argThat(m ->
+              "visitor".equals(m.getSenderRole()) && "More info".equals(m.getContent())));
+      // updatedAt must have been explicitly set before threadRepo.save
+      assertThat(thread.getUpdatedAt()).isAfter(oldTime);
+      verify(threadRepo).save(thread);
+  }
+  ```
+
+  Add `import java.time.Instant;` if not present (it's already in the test file via `MessageThread` usage — but add it explicitly at the top if the compiler complains).
+
+- [ ] **Step 2: Run to confirm the new assertion fails**
+
+  ```bash
+  mvn test -pl . -Dtest=MessageServiceTest#addMessage_knownThread_savesVisitorMessageAndBumpsThread -q
+  ```
+
+  Expected: FAIL — assertion error on `thread.getUpdatedAt()` because the service does not yet set it.
+
+- [ ] **Step 3: Fix MessageService.addMessage — explicitly set updatedAt before save**
+
+  Open `src/main/java/com/advisorplatform/service/MessageService.java`.
+
+  Replace the `addMessage` method body:
+
+  ```java
+  @Transactional
+  public ThreadMessage addMessage(UUID threadId, String content) {
+      MessageThread thread = threadRepo.findById(threadId)
+              .orElseThrow(() -> new IllegalArgumentException("Thread not found: " + threadId));
+
+      ThreadMessage message = ThreadMessage.builder()
+              .thread(thread)
+              .senderRole("visitor")
+              .content(content)
+              .build();
+      message = messageRepo.save(message);
+
+      // Dirty the entity so Hibernate issues UPDATE and updatedAt is refreshed
+      thread.setUpdatedAt(Instant.now());
+      threadRepo.save(thread);
+
+      return message;
+  }
+  ```
+
+  Add `import java.time.Instant;` at the top of the file (it may already be present — check the imports).
+
+- [ ] **Step 4: Run all MessageService tests to confirm they pass**
+
+  ```bash
+  mvn test -pl . -Dtest=MessageServiceTest -q
+  ```
+
+  Expected: all 8 tests pass (BUILD SUCCESS).
+
+- [ ] **Step 5: Commit**
+
+  ```bash
+  git add src/main/java/com/advisorplatform/service/MessageService.java \
+          src/test/java/com/advisorplatform/service/MessageServiceTest.java
+  git commit -m "fix: explicitly set updatedAt in addMessage so Hibernate issues UPDATE"
+  ```
+
+---
+
+### Task 2: Remove @Transactional from streamChat
+
+**Files:**
+- Modify: `src/main/java/com/advisorplatform/ai/PlannerAiService.java`
+
+No test changes — the existing `PlannerAiServiceTest.streamChat_knownSession_emitsChunksAndPersistsOnComplete` already verifies persistence.
+
+- [ ] **Step 1: Remove @Transactional and update Javadoc in streamChat**
+
+  Open `src/main/java/com/advisorplatform/ai/PlannerAiService.java`.
+
+  Replace the `streamChat` method's annotation and Javadoc block:
+
+  ```java
+  /**
+   * Streaming version — returns a Flux of text chunks for SSE.
+   * User message is persisted immediately; assistant message is persisted in a
+   * separate transaction when the stream completes.
+   */
+  public Flux<String> streamChat(UUID sessionId, String userContent) {
+  ```
+
+  (Remove the `@Transactional` annotation line entirely; keep everything else in the method body unchanged.)
+
+  Also remove the `import org.springframework.transaction.annotation.Transactional;` line **only if** it is no longer used — `chat()` still has `@Transactional`, so the import remains needed.
+
+- [ ] **Step 2: Run PlannerAiService tests to confirm nothing regressed**
+
+  ```bash
+  mvn test -pl . -Dtest=PlannerAiServiceTest -q
+  ```
+
+  Expected: all tests pass (BUILD SUCCESS).
+
+- [ ] **Step 3: Commit**
+
+  ```bash
+  git add src/main/java/com/advisorplatform/ai/PlannerAiService.java
+  git commit -m "fix: remove @Transactional from streamChat — annotation is a no-op on Flux return type"
+  ```
+
+---
+
+### Task 3: Global Exception Handler for IllegalArgumentException
+
+**Files:**
+- Create: `src/main/java/com/advisorplatform/api/GlobalExceptionHandler.java`
+- Modify: `src/test/java/com/advisorplatform/api/MessageControllerTest.java`
+- Modify: `src/test/java/com/advisorplatform/api/ChatControllerTest.java`
+
+- [ ] **Step 1: Write failing test in MessageControllerTest**
+
+  Open `src/test/java/com/advisorplatform/api/MessageControllerTest.java`.
+
+  Add this test method after the existing `createThread_blankContent_returns400` test:
+
+  ```java
+  @Test
+  void createThread_serviceThrowsIllegalArgument_returns400() throws Exception {
+      when(messageService.createThread(any(), any(), any(), any()))
+              .thenThrow(new IllegalArgumentException("Visitor not found: some-id"));
+
+      mockMvc.perform(post("/api/message")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content("{\"visitorId\":\"" + UUID.randomUUID() + "\","
+                              + "\"content\":\"Hello\"}"))
+              .andExpect(status().isBadRequest());
+  }
+  ```
+
+- [ ] **Step 2: Write failing test in ChatControllerTest**
+
+  Open `src/test/java/com/advisorplatform/api/ChatControllerTest.java`.
+
+  Add this test method after the existing `createSession_validVisitorId_returns200WithSessionId` test:
+
+  ```java
+  @Test
+  void createSession_serviceThrowsIllegalArgument_returns400() throws Exception {
+      when(visitorService.createSession(any()))
+              .thenThrow(new IllegalArgumentException("Visitor not found: some-id"));
+
+      mockMvc.perform(post("/api/session")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content("{\"visitorId\":\"" + UUID.randomUUID() + "\"}"))
+              .andExpect(status().isBadRequest());
+  }
+  ```
+
+- [ ] **Step 3: Run the two new tests to confirm they fail**
+
+  ```bash
+  mvn test -pl . -Dtest="MessageControllerTest#createThread_serviceThrowsIllegalArgument_returns400+ChatControllerTest#createSession_serviceThrowsIllegalArgument_returns400" -q
+  ```
+
+  Expected: FAIL — both tests get 500 (no handler yet).
+
+- [ ] **Step 4: Create GlobalExceptionHandler**
+
+  Create `src/main/java/com/advisorplatform/api/GlobalExceptionHandler.java`:
+
+  ```java
+  package com.advisorplatform.api;
+
+  import org.springframework.http.ResponseEntity;
+  import org.springframework.web.bind.annotation.ExceptionHandler;
+  import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+  @RestControllerAdvice
+  class GlobalExceptionHandler {
+
+      @ExceptionHandler(IllegalArgumentException.class)
+      ResponseEntity<String> handleBadArgument(IllegalArgumentException ex) {
+          return ResponseEntity.badRequest().body(ex.getMessage());
+      }
+  }
+  ```
+
+- [ ] **Step 5: Run both controller test classes to confirm all tests pass**
+
+  ```bash
+  mvn test -pl . -Dtest="MessageControllerTest,ChatControllerTest" -q
+  ```
+
+  Expected: all tests pass (BUILD SUCCESS).
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add src/main/java/com/advisorplatform/api/GlobalExceptionHandler.java \
+          src/test/java/com/advisorplatform/api/MessageControllerTest.java \
+          src/test/java/com/advisorplatform/api/ChatControllerTest.java
+  git commit -m "fix: add GlobalExceptionHandler — map IllegalArgumentException to 400"
+  ```
+
+---
+
+### Task 4: @NotNull on visitorId in Request Records
+
+**Files:**
+- Modify: `src/main/java/com/advisorplatform/api/MessageController.java`
+- Modify: `src/main/java/com/advisorplatform/api/ChatController.java`
+- Modify: `src/test/java/com/advisorplatform/api/MessageControllerTest.java`
+- Modify: `src/test/java/com/advisorplatform/api/ChatControllerTest.java`
+
+- [ ] **Step 1: Write failing test for null visitorId in MessageControllerTest**
+
+  Open `src/test/java/com/advisorplatform/api/MessageControllerTest.java`.
+
+  Add this test after `createThread_serviceThrowsIllegalArgument_returns400`:
+
+  ```java
+  @Test
+  void createThread_nullVisitorId_returns400() throws Exception {
+      mockMvc.perform(post("/api/message")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content("{\"visitorId\":null,\"content\":\"Hello\"}"))
+              .andExpect(status().isBadRequest());
+  }
+  ```
+
+- [ ] **Step 2: Write failing test for null visitorId in ChatControllerTest**
+
+  Open `src/test/java/com/advisorplatform/api/ChatControllerTest.java`.
+
+  Add this test after `createSession_serviceThrowsIllegalArgument_returns400`:
+
+  ```java
+  @Test
+  void createSession_nullVisitorId_returns400() throws Exception {
+      mockMvc.perform(post("/api/session")
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content("{\"visitorId\":null}"))
+              .andExpect(status().isBadRequest());
+  }
+  ```
+
+- [ ] **Step 3: Run the two new tests to confirm they fail**
+
+  ```bash
+  mvn test -pl . -Dtest="MessageControllerTest#createThread_nullVisitorId_returns400+ChatControllerTest#createSession_nullVisitorId_returns400" -q
+  ```
+
+  Expected: FAIL — both tests get 200 (null passes @Valid without @NotNull).
+
+- [ ] **Step 4: Add @NotNull to CreateThreadRequest in MessageController**
+
+  Open `src/main/java/com/advisorplatform/api/MessageController.java`.
+
+  Replace the `CreateThreadRequest` record:
+
+  ```java
+  record CreateThreadRequest(@NotNull UUID visitorId, UUID aiSessionId, String subject, @NotBlank String content) {}
+  ```
+
+  Add `import jakarta.validation.constraints.NotNull;` to the imports.
+
+- [ ] **Step 5: Add @NotNull to CreateSessionRequest in ChatController**
+
+  Open `src/main/java/com/advisorplatform/api/ChatController.java`.
+
+  Replace the `CreateSessionRequest` record:
+
+  ```java
+  record CreateSessionRequest(@NotNull UUID visitorId) {}
+  ```
+
+  Add `import jakarta.validation.constraints.NotNull;` to the imports.
+
+- [ ] **Step 6: Run both controller test classes to confirm all tests pass**
+
+  ```bash
+  mvn test -pl . -Dtest="MessageControllerTest,ChatControllerTest" -q
+  ```
+
+  Expected: all tests pass (BUILD SUCCESS).
+
+- [ ] **Step 7: Commit**
+
+  ```bash
+  git add src/main/java/com/advisorplatform/api/MessageController.java \
+          src/main/java/com/advisorplatform/api/ChatController.java \
+          src/test/java/com/advisorplatform/api/MessageControllerTest.java \
+          src/test/java/com/advisorplatform/api/ChatControllerTest.java
+  git commit -m "fix: add @NotNull to visitorId in CreateThreadRequest and CreateSessionRequest"
+  ```
+
+---
+
+### Task 5: Visitor Follow-Up Endpoint POST /api/thread/{threadId}/messages
+
+**Files:**
+- Modify: `src/main/java/com/advisorplatform/api/MessageController.java`
+- Modify: `src/test/java/com/advisorplatform/api/MessageControllerTest.java`
+
+- [ ] **Step 1: Write failing tests for the new endpoint**
+
+  Open `src/test/java/com/advisorplatform/api/MessageControllerTest.java`.
+
+  Add these two test methods after `createThread_nullVisitorId_returns400`:
+
+  ```java
+  // ── POST /api/thread/{threadId}/messages ─────────────────────────────────
+
+  @Test
+  void addMessage_validContent_returns200WithMessageId() throws Exception {
+      UUID threadId = UUID.randomUUID();
+      UUID messageId = UUID.randomUUID();
+      ThreadMessage message = ThreadMessage.builder()
+              .thread(MessageThread.builder().visitor(new Visitor()).build())
+              .senderRole("visitor")
+              .content("Follow up question")
+              .build();
+      ReflectionTestUtils.setField(message, "id", messageId);
+      when(messageService.addMessage(eq(threadId), eq("Follow up question"))).thenReturn(message);
+
+      mockMvc.perform(post("/api/thread/{threadId}/messages", threadId)
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content("{\"content\":\"Follow up question\"}"))
+              .andExpect(status().isOk())
+              .andExpect(jsonPath("$.messageId").value(messageId.toString()));
+  }
+
+  @Test
+  void addMessage_blankContent_returns400() throws Exception {
+      mockMvc.perform(post("/api/thread/{threadId}/messages", UUID.randomUUID())
+                      .contentType(MediaType.APPLICATION_JSON)
+                      .content("{\"content\":\"\"}"))
+              .andExpect(status().isBadRequest());
+  }
+  ```
+
+- [ ] **Step 2: Run new tests to confirm they fail**
+
+  ```bash
+  mvn test -pl . -Dtest="MessageControllerTest#addMessage_validContent_returns200WithMessageId+MessageControllerTest#addMessage_blankContent_returns400" -q
+  ```
+
+  Expected: FAIL — 404 (no route exists yet).
+
+- [ ] **Step 3: Add the endpoint and new records to MessageController**
+
+  Open `src/main/java/com/advisorplatform/api/MessageController.java`.
+
+  Add this handler method after the `getMessages` method (before the records section):
+
+  ```java
+  /** Add a follow-up visitor message to an existing thread. */
+  @PostMapping("/thread/{threadId}/messages")
+  public ResponseEntity<AddMessageResponse> addMessage(
+          @PathVariable UUID threadId,
+          @Valid @RequestBody AddMessageRequest req) {
+      ThreadMessage message = messageService.addMessage(threadId, req.content());
+      return ResponseEntity.ok(new AddMessageResponse(message.getId()));
+  }
+  ```
+
+  Add these two records to the records section at the bottom of the class:
+
+  ```java
+  record AddMessageRequest(@NotBlank String content) {}
+  record AddMessageResponse(UUID messageId) {}
+  ```
+
+- [ ] **Step 4: Run all MessageController tests**
+
+  ```bash
+  mvn test -pl . -Dtest=MessageControllerTest -q
+  ```
+
+  Expected: all tests pass (BUILD SUCCESS).
+
+- [ ] **Step 5: Run the full test suite to confirm no regressions**
+
+  ```bash
+  mvn test -q
+  ```
+
+  Expected: all tests pass (BUILD SUCCESS). The suite currently has 29 tests; it should now have at minimum 37 (6 new: 1 in MessageServiceTest, 1 in MessageControllerTest×2 for Fix 4, 2 in ChatControllerTest×2 for Fix 4, 2 new for Fix 5, 2 new for Fix 1 — 8 total new tests = 37).
+
+- [ ] **Step 6: Commit**
+
+  ```bash
+  git add src/main/java/com/advisorplatform/api/MessageController.java \
+          src/test/java/com/advisorplatform/api/MessageControllerTest.java
+  git commit -m "feat: add POST /api/thread/{threadId}/messages endpoint for visitor follow-up"
+  ```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+- Fix 1 (follow-up endpoint): Task 5 — endpoint, records, 2 new tests ✓
+- Fix 2 (updatedAt bump): Task 1 — service fix + extended assertion ✓
+- Fix 3 (@Transactional removal): Task 2 — annotation removed, Javadoc updated ✓
+- Fix 4 (global handler): Task 3 — new file + 2 cross-controller tests ✓
+- Fix 5 (@NotNull): Task 4 — two record changes + 2 new tests ✓
+
+**Placeholder scan:** No TBDs. All code blocks are complete and self-contained.
+
+**Type consistency:** `messageService.addMessage(UUID, String)` used in Task 5 matches existing signature in `MessageService`. `ThreadMessage.getId()` exists via `@Getter`. `AddMessageResponse.messageId` matches the record field. All consistent.

--- a/docs/superpowers/plans/2026-04-01-architecture-docs.md
+++ b/docs/superpowers/plans/2026-04-01-architecture-docs.md
@@ -1,0 +1,750 @@
+# Architecture Documentation — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create Mermaid-based architecture diagrams and lightweight ADRs that serve as onboarding reference, design review aid, and living documentation.
+
+**Architecture:** All diagrams are Mermaid code blocks embedded inline in `docs/ARCHITECTURE.md` so they render natively on GitHub without extra tooling. Separate `.mmd` source files in `docs/architecture/diagrams/` are kept for editor tooling. ADRs follow a lightweight Status/Context/Decision/Consequences format.
+
+**Tech Stack:** Mermaid (GitHub-native rendering), Markdown.
+
+---
+
+## File Map
+
+**Create:**
+- `docs/ARCHITECTURE.md`
+- `docs/architecture/diagrams/c4-context.mmd`
+- `docs/architecture/diagrams/visitor-session-flow.mmd`
+- `docs/architecture/diagrams/ai-streaming-pipeline.mmd`
+- `docs/architecture/diagrams/message-threading-workflow.mmd`
+- `docs/architecture/diagrams/entity-relationships.mmd`
+- `docs/architecture/ADR-001-session-identity.md`
+- `docs/architecture/ADR-002-ai-streaming.md`
+- `docs/architecture/ADR-003-message-threading.md`
+
+---
+
+## Task 1: C4 Context Diagram + ARCHITECTURE.md Entry Point
+
+**Files:**
+- Create: `docs/architecture/diagrams/c4-context.mmd`
+- Create: `docs/ARCHITECTURE.md` (initial version — more diagrams added in later tasks)
+
+- [ ] **Step 1: Create `docs/architecture/diagrams/c4-context.mmd`**
+
+```
+C4Context
+    title System Context — Advisor Platform
+
+    Person(visitor, "Visitor", "Website visitor seeking travel planning advice")
+    Person(advisor, "Advisor", "Travel advisor reviewing visitor inquiries")
+
+    System_Boundary(platform, "Advisor Platform") {
+        System(api, "Backend API", "Spring Boot 3.4 — handles AI chat, visitor identity, and advisor messaging")
+    }
+
+    System_Ext(anthropic, "Anthropic API", "Claude AI model — generates travel advice responses")
+    SystemDb_Ext(postgres, "PostgreSQL 16", "Stores visitors, AI sessions, messages, and threads")
+
+    Rel(visitor, api, "Identifies, chats with AI, sends advisor messages", "HTTPS/JSON + SSE")
+    Rel(advisor, api, "Reviews threads, replies to visitors", "HTTPS/JSON")
+    Rel(api, anthropic, "Streams AI completions", "HTTPS")
+    Rel(api, postgres, "Reads and writes data", "JDBC/Flyway")
+```
+
+- [ ] **Step 2: Create `docs/ARCHITECTURE.md` with the C4 diagram and table of contents**
+
+```markdown
+# Advisor Platform — Architecture
+
+This document is the entry point for understanding the system. It contains the high-level context diagram, links to detailed sequence and flow diagrams, and links to Architecture Decision Records (ADRs).
+
+---
+
+## System Context
+
+```mermaid
+C4Context
+    title System Context — Advisor Platform
+
+    Person(visitor, "Visitor", "Website visitor seeking travel planning advice")
+    Person(advisor, "Advisor", "Travel advisor reviewing visitor inquiries")
+
+    System_Boundary(platform, "Advisor Platform") {
+        System(api, "Backend API", "Spring Boot 3.4 — handles AI chat, visitor identity, and advisor messaging")
+    }
+
+    System_Ext(anthropic, "Anthropic API", "Claude AI model — generates travel advice responses")
+    SystemDb_Ext(postgres, "PostgreSQL 16", "Stores visitors, AI sessions, messages, and threads")
+
+    Rel(visitor, api, "Identifies, chats with AI, sends advisor messages", "HTTPS/JSON + SSE")
+    Rel(advisor, api, "Reviews threads, replies to visitors", "HTTPS/JSON")
+    Rel(api, anthropic, "Streams AI completions", "HTTPS")
+    Rel(api, postgres, "Reads and writes data", "JDBC/Flyway")
+```
+
+---
+
+## Diagrams
+
+| Diagram | What It Shows |
+|---|---|
+| [Visitor Identity + Session Flow](architecture/diagrams/visitor-session-flow.mmd) | How a visitor is identified on page load, sessions created, and AI chat initiated |
+| [AI Streaming Pipeline](architecture/diagrams/ai-streaming-pipeline.mmd) | How SSE streaming chat flows through Spring AI to Anthropic and back, with persistence |
+| [Message Threading Workflow](architecture/diagrams/message-threading-workflow.mmd) | Thread state machine from visitor submission through advisor reply |
+| [Entity Relationships](architecture/diagrams/entity-relationships.mmd) | All 5 entities and their FK relationships |
+
+---
+
+## Architecture Decision Records
+
+| ADR | Decision |
+|---|---|
+| [ADR-001](architecture/ADR-001-session-identity.md) | Session identity: browser token + find-or-create instead of authenticated users |
+| [ADR-002](architecture/ADR-002-ai-streaming.md) | AI streaming: SSE with post-stream persistence |
+| [ADR-003](architecture/ADR-003-message-threading.md) | Message threading: separate from AI sessions, visitor/advisor role model |
+
+---
+
+## Package Structure
+
+```
+src/main/java/com/advisorplatform/
+├── api/           ApiDelegate implementations (HTTP layer)
+├── service/       Business logic and orchestration
+├── domain/
+│   ├── entity/    JPA entities
+│   └── repository/ Spring Data repositories
+├── ai/            Spring AI + Anthropic integration
+└── config/        Spring configuration beans
+
+src/main/resources/api/   OpenAPI 3 spec files (one per domain)
+target/generated-sources/ Generated Spring interfaces + POJOs — do not edit
+```
+
+---
+
+## Maintenance
+
+When a PR changes the API surface or database schema, update the relevant diagram and/or ADR as part of the same PR.
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/ARCHITECTURE.md docs/architecture/diagrams/c4-context.mmd
+git commit -m "docs: add ARCHITECTURE.md entry point with C4 context diagram (#<issue-number>)"
+```
+
+---
+
+## Task 2: Visitor Identity + Session Flow Diagram
+
+**Files:**
+- Create: `docs/architecture/diagrams/visitor-session-flow.mmd`
+- Modify: `docs/ARCHITECTURE.md` — embed diagram inline
+
+- [ ] **Step 1: Create `docs/architecture/diagrams/visitor-session-flow.mmd`**
+
+```
+sequenceDiagram
+    participant Browser
+    participant API as Advisor Platform API
+    participant DB as PostgreSQL
+
+    Note over Browser,DB: Page load — visitor identification
+
+    Browser->>API: POST /api/visitor/identify {browserToken}
+    API->>DB: SELECT * FROM visitor WHERE browser_token = ?
+    alt Visitor exists
+        DB-->>API: Visitor row
+        API->>DB: UPDATE visitor SET last_seen_at = now()
+    else New visitor
+        API->>DB: INSERT INTO visitor (browser_token)
+        DB-->>API: New Visitor row
+    end
+    API-->>Browser: {visitorId, browserToken}
+
+    Note over Browser,DB: Session creation
+
+    Browser->>API: POST /api/session {visitorId}
+    API->>DB: SELECT * FROM visitor WHERE id = ?
+    DB-->>API: Visitor row
+    API->>DB: INSERT INTO ai_session (visitor_id)
+    DB-->>API: AiSession row
+    API-->>Browser: {sessionId, createdAt}
+
+    Note over Browser,DB: Non-streaming chat
+
+    Browser->>API: POST /api/chat/{sessionId} {message}
+    API->>DB: SELECT * FROM ai_message WHERE session_id = ? ORDER BY created_at
+    DB-->>API: Message history
+    API->>DB: INSERT INTO ai_message (session_id, role='user', content)
+    API->>+Anthropic: Messages API call (history + new message)
+    Anthropic-->>-API: Assistant response
+    API->>DB: INSERT INTO ai_message (session_id, role='assistant', content, model, tokens)
+    API-->>Browser: {messageId, content, model, createdAt}
+```
+
+- [ ] **Step 2: Add the diagram inline to `docs/ARCHITECTURE.md`**
+
+Insert after the C4 context section and before the Diagrams table. Replace the placeholder table entry with an inline embed:
+
+Append this section to `docs/ARCHITECTURE.md` before the `## Diagrams` table:
+
+```markdown
+## Visitor Identity + Session Flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant API as Advisor Platform API
+    participant DB as PostgreSQL
+
+    Note over Browser,DB: Page load — visitor identification
+
+    Browser->>API: POST /api/visitor/identify {browserToken}
+    API->>DB: SELECT * FROM visitor WHERE browser_token = ?
+    alt Visitor exists
+        DB-->>API: Visitor row
+        API->>DB: UPDATE visitor SET last_seen_at = now()
+    else New visitor
+        API->>DB: INSERT INTO visitor (browser_token)
+        DB-->>API: New Visitor row
+    end
+    API-->>Browser: {visitorId, browserToken}
+
+    Note over Browser,DB: Session creation
+
+    Browser->>API: POST /api/session {visitorId}
+    API->>DB: SELECT * FROM visitor WHERE id = ?
+    DB-->>API: Visitor row
+    API->>DB: INSERT INTO ai_session (visitor_id)
+    DB-->>API: AiSession row
+    API-->>Browser: {sessionId, createdAt}
+
+    Note over Browser,DB: Non-streaming chat
+
+    Browser->>API: POST /api/chat/{sessionId} {message}
+    API->>DB: SELECT * FROM ai_message WHERE session_id = ? ORDER BY created_at
+    DB-->>API: Message history
+    API->>DB: INSERT INTO ai_message (session_id, role='user', content)
+    API->>+Anthropic: Messages API call (history + new message)
+    Anthropic-->>-API: Assistant response
+    API->>DB: INSERT INTO ai_message (session_id, role='assistant', content, model, tokens)
+    API-->>Browser: {messageId, content, model, createdAt}
+```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture/diagrams/visitor-session-flow.mmd docs/ARCHITECTURE.md
+git commit -m "docs: add visitor identity and session flow sequence diagram (#<issue-number>)"
+```
+
+---
+
+## Task 3: AI Streaming Pipeline Diagram
+
+**Files:**
+- Create: `docs/architecture/diagrams/ai-streaming-pipeline.mmd`
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Create `docs/architecture/diagrams/ai-streaming-pipeline.mmd`**
+
+```
+sequenceDiagram
+    participant Browser
+    participant API as Advisor Platform API
+    participant SpringAI as Spring AI (ChatModel)
+    participant Anthropic as Anthropic API
+    participant DB as PostgreSQL
+
+    Browser->>API: POST /api/chat/{sessionId}/stream {message}
+    Note over API: SSE connection established (text/event-stream)
+
+    API->>DB: SELECT * FROM ai_message WHERE session_id = ? ORDER BY created_at
+    DB-->>API: Message history (up to maxHistoryTurns window)
+
+    API->>DB: INSERT INTO ai_message (role='user', content)
+    DB-->>API: Saved
+
+    API->>SpringAI: ChatModel.stream(systemPrompt + history + userMessage)
+    SpringAI->>Anthropic: POST /v1/messages (streaming: true)
+
+    loop Token stream
+        Anthropic-->>SpringAI: data: {delta: {text: "chunk"}}
+        SpringAI-->>API: Flux<ChatResponse> chunk
+        API-->>Browser: data: chunk\n\n
+    end
+
+    Anthropic-->>SpringAI: data: [DONE]
+    SpringAI-->>API: Flux complete (doOnComplete triggered)
+
+    API->>DB: INSERT INTO ai_message (role='assistant', full content, model, latency_ms)
+    Note over Browser: SSE connection closes
+```
+
+- [ ] **Step 2: Add diagram inline to `docs/ARCHITECTURE.md`**
+
+Append this section to `docs/ARCHITECTURE.md`:
+
+```markdown
+## AI Streaming Pipeline
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant API as Advisor Platform API
+    participant SpringAI as Spring AI (ChatModel)
+    participant Anthropic as Anthropic API
+    participant DB as PostgreSQL
+
+    Browser->>API: POST /api/chat/{sessionId}/stream {message}
+    Note over API: SSE connection established (text/event-stream)
+
+    API->>DB: SELECT * FROM ai_message WHERE session_id = ? ORDER BY created_at
+    DB-->>API: Message history (up to maxHistoryTurns window)
+
+    API->>DB: INSERT INTO ai_message (role='user', content)
+    DB-->>API: Saved
+
+    API->>SpringAI: ChatModel.stream(systemPrompt + history + userMessage)
+    SpringAI->>Anthropic: POST /v1/messages (streaming: true)
+
+    loop Token stream
+        Anthropic-->>SpringAI: data: {delta: {text: "chunk"}}
+        SpringAI-->>API: Flux<ChatResponse> chunk
+        API-->>Browser: data: chunk\n\n
+    end
+
+    Anthropic-->>SpringAI: data: [DONE]
+    SpringAI-->>API: Flux complete (doOnComplete triggered)
+
+    API->>DB: INSERT INTO ai_message (role='assistant', full content, model, latency_ms)
+    Note over Browser: SSE connection closes
+```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture/diagrams/ai-streaming-pipeline.mmd docs/ARCHITECTURE.md
+git commit -m "docs: add AI streaming pipeline sequence diagram (#<issue-number>)"
+```
+
+---
+
+## Task 4: Message Threading Workflow Diagram
+
+**Files:**
+- Create: `docs/architecture/diagrams/message-threading-workflow.mmd`
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Create `docs/architecture/diagrams/message-threading-workflow.mmd`**
+
+```
+flowchart TD
+    A([Visitor submits initial message]) --> B
+
+    B["POST /api/message\n─────────────────\nCreates MessageThread\nstatus = 'open'\nCreates ThreadMessage\nsenderRole = 'visitor'"]
+
+    B --> C{Advisor action}
+
+    C -->|View thread| D["GET /api/thread/:id/messages\nReturns all messages"]
+    D --> C
+
+    C -->|Reply ➜ Phase 2| E["POST /api/thread/:id/reply\nAdds ThreadMessage\nsenderRole = 'advisor'\nstatus → 'pending_reply'"]
+    E --> F{Visitor follow-up?}
+
+    F -->|Yes| G["POST /api/thread/:id/messages\nAdds ThreadMessage\nsenderRole = 'visitor'\nstatus → 'open'"]
+    G --> C
+
+    F -->|No| C
+
+    C -->|Resolve ➜ Phase 2| H["PATCH /api/thread/:id/status\nstatus = 'resolved'"]
+    C -->|Close ➜ Phase 2| I["PATCH /api/thread/:id/status\nstatus = 'closed'"]
+
+    H --> J([Thread archived])
+    I --> J
+
+    style E stroke-dasharray: 5 5
+    style H stroke-dasharray: 5 5
+    style I stroke-dasharray: 5 5
+```
+
+Note: Dashed borders indicate Phase 2 endpoints (not yet implemented).
+
+- [ ] **Step 2: Add diagram inline to `docs/ARCHITECTURE.md`**
+
+Append this section to `docs/ARCHITECTURE.md`:
+
+```markdown
+## Message Threading Workflow
+
+> Dashed nodes indicate Phase 2 endpoints not yet implemented.
+
+```mermaid
+flowchart TD
+    A([Visitor submits initial message]) --> B
+
+    B["POST /api/message\n─────────────────\nCreates MessageThread\nstatus = 'open'\nCreates ThreadMessage\nsenderRole = 'visitor'"]
+
+    B --> C{Advisor action}
+
+    C -->|View thread| D["GET /api/thread/:id/messages\nReturns all messages"]
+    D --> C
+
+    C -->|Reply ➜ Phase 2| E["POST /api/thread/:id/reply\nAdds ThreadMessage\nsenderRole = 'advisor'\nstatus → 'pending_reply'"]
+    E --> F{Visitor follow-up?}
+
+    F -->|Yes| G["POST /api/thread/:id/messages\nAdds ThreadMessage\nsenderRole = 'visitor'\nstatus → 'open'"]
+    G --> C
+
+    F -->|No| C
+
+    C -->|Resolve ➜ Phase 2| H["PATCH /api/thread/:id/status\nstatus = 'resolved'"]
+    C -->|Close ➜ Phase 2| I["PATCH /api/thread/:id/status\nstatus = 'closed'"]
+
+    H --> J([Thread archived])
+    I --> J
+
+    style E stroke-dasharray: 5 5
+    style H stroke-dasharray: 5 5
+    style I stroke-dasharray: 5 5
+```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture/diagrams/message-threading-workflow.mmd docs/ARCHITECTURE.md
+git commit -m "docs: add message threading workflow flowchart (#<issue-number>)"
+```
+
+---
+
+## Task 5: Entity Relationship Diagram
+
+**Files:**
+- Create: `docs/architecture/diagrams/entity-relationships.mmd`
+- Modify: `docs/ARCHITECTURE.md`
+
+- [ ] **Step 1: Create `docs/architecture/diagrams/entity-relationships.mmd`**
+
+```
+erDiagram
+    VISITOR {
+        uuid id PK
+        varchar browser_token UK
+        varchar email UK
+        boolean email_verified
+        timestamptz tos_accepted_at
+        varchar tos_version
+        timestamptz created_at
+        timestamptz last_seen_at
+    }
+
+    AI_SESSION {
+        uuid id PK
+        uuid visitor_id FK
+        timestamptz created_at
+    }
+
+    AI_MESSAGE {
+        uuid id PK
+        uuid session_id FK
+        varchar role
+        text content
+        varchar model_version
+        int token_count
+        int latency_ms
+        timestamptz created_at
+    }
+
+    MESSAGE_THREAD {
+        uuid id PK
+        uuid visitor_id FK
+        uuid ai_session_id FK
+        varchar subject
+        varchar status
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    THREAD_MESSAGE {
+        uuid id PK
+        uuid thread_id FK
+        varchar sender_role
+        text content
+        timestamptz created_at
+    }
+
+    VISITOR ||--o{ AI_SESSION : "has"
+    AI_SESSION ||--o{ AI_MESSAGE : "contains"
+    VISITOR ||--o{ MESSAGE_THREAD : "owns"
+    AI_SESSION |o--o{ MESSAGE_THREAD : "optionally linked to"
+    MESSAGE_THREAD ||--o{ THREAD_MESSAGE : "contains"
+```
+
+- [ ] **Step 2: Add diagram inline to `docs/ARCHITECTURE.md`**
+
+Append this section to `docs/ARCHITECTURE.md`:
+
+```markdown
+## Entity Relationships
+
+```mermaid
+erDiagram
+    VISITOR {
+        uuid id PK
+        varchar browser_token UK
+        varchar email UK
+        boolean email_verified
+        timestamptz tos_accepted_at
+        varchar tos_version
+        timestamptz created_at
+        timestamptz last_seen_at
+    }
+
+    AI_SESSION {
+        uuid id PK
+        uuid visitor_id FK
+        timestamptz created_at
+    }
+
+    AI_MESSAGE {
+        uuid id PK
+        uuid session_id FK
+        varchar role
+        text content
+        varchar model_version
+        int token_count
+        int latency_ms
+        timestamptz created_at
+    }
+
+    MESSAGE_THREAD {
+        uuid id PK
+        uuid visitor_id FK
+        uuid ai_session_id FK
+        varchar subject
+        varchar status
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    THREAD_MESSAGE {
+        uuid id PK
+        uuid thread_id FK
+        varchar sender_role
+        text content
+        timestamptz created_at
+    }
+
+    VISITOR ||--o{ AI_SESSION : "has"
+    AI_SESSION ||--o{ AI_MESSAGE : "contains"
+    VISITOR ||--o{ MESSAGE_THREAD : "owns"
+    AI_SESSION |o--o{ MESSAGE_THREAD : "optionally linked to"
+    MESSAGE_THREAD ||--o{ THREAD_MESSAGE : "contains"
+```
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture/diagrams/entity-relationships.mmd docs/ARCHITECTURE.md
+git commit -m "docs: add entity relationship diagram (#<issue-number>)"
+```
+
+---
+
+## Task 6: Write ADR-001 — Session Identity
+
+**Files:**
+- Create: `docs/architecture/ADR-001-session-identity.md`
+
+- [ ] **Step 1: Create `docs/architecture/ADR-001-session-identity.md`**
+
+```markdown
+# ADR-001: Session Identity — Browser Token + Find-or-Create
+
+**Status:** Accepted
+**Date:** 2026-04-01
+
+---
+
+## Context
+
+The platform needs to identify visitors across page loads without requiring account creation. Phase 1 targets first-time visitors who want to plan a trip immediately, without friction. Requiring email/password login upfront would reduce conversion.
+
+We also need to link AI chat sessions and message threads to a persistent visitor identity, so returning visitors can see their history.
+
+## Decision
+
+Use a randomly-generated browser token stored in `localStorage` as the visitor identity for Phase 1.
+
+On every page load, the frontend calls `POST /api/visitor/identify` with the stored token. The backend does a find-or-create on the `visitor` table using `browser_token` as a unique key, updating `last_seen_at` on each visit.
+
+No password, no email, no session cookie — just a UUID in localStorage.
+
+## Consequences
+
+**Positive:**
+- Zero friction for new visitors — no sign-up required
+- Simple to implement and reason about
+- History persists across sessions on the same device/browser
+
+**Negative:**
+- Identity is lost if the user clears localStorage or switches browsers
+- No way to merge identities (e.g., same user on mobile and desktop)
+- No authentication — any client with a valid `visitorId` can access that visitor's data
+
+**Phase 2 plan:** Replace with Supabase-based auth (JWT verification in `infra/`). The `visitor` table already has `email` and `email_verified` columns for this transition. The `visitorId` in all requests will map to the authenticated user once auth is in place.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/architecture/ADR-001-session-identity.md
+git commit -m "docs: add ADR-001 session identity decision record (#<issue-number>)"
+```
+
+---
+
+## Task 7: Write ADR-002 — AI Streaming
+
+**Files:**
+- Create: `docs/architecture/ADR-002-ai-streaming.md`
+
+- [ ] **Step 1: Create `docs/architecture/ADR-002-ai-streaming.md`**
+
+```markdown
+# ADR-002: AI Streaming — SSE with Post-Stream Persistence
+
+**Status:** Accepted
+**Date:** 2026-04-01
+
+---
+
+## Context
+
+The AI chat feature calls the Anthropic Claude API, which can take 5-30 seconds to generate a full response. Waiting for the full response before returning to the browser creates a poor user experience — the UI appears frozen.
+
+We need a streaming strategy that:
+1. Shows tokens to the user as they arrive
+2. Persists the full conversation turn to the database
+3. Maintains the conversation history for multi-turn context
+
+## Decision
+
+Use Server-Sent Events (SSE) for streaming. The `/api/chat/{sessionId}/stream` endpoint returns `Content-Type: text/event-stream` and yields text tokens via a `Flux<String>` backed by Spring AI's `ChatModel.stream()`.
+
+**Persistence timing:**
+- The user message is persisted **before** the stream begins (so history is correct on retry)
+- The assistant message is persisted **after** the stream completes, using `Flux.doOnComplete()`
+- The full assistant content is accumulated in a `StringBuilder` during streaming
+
+**History loading:**
+- Message history is loaded **before** the user message is persisted to avoid the user's new message appearing twice in the context window (once in history, once as the final UserMessage)
+
+## Consequences
+
+**Positive:**
+- Perceived responsiveness is greatly improved — users see text immediately
+- Spring AI + Project Reactor (`Flux`) handle backpressure and cancellation natively
+- Simple implementation — no WebSocket, no custom SSE infrastructure
+
+**Negative:**
+- If the client disconnects mid-stream, `doOnComplete()` may not fire — the assistant message may not be persisted
+- Token count is unavailable during streaming (the Anthropic stream metadata arrives at the end); currently stored as 0 for stream responses
+- Non-streaming (`POST /api/chat/{sessionId}`) is maintained as a fallback for testing and clients that don't support SSE
+
+**Future improvement:** Use `doOnNext()` + a final `doOnComplete()` callback with the accumulated tokens metadata if the Anthropic SDK exposes it in the stream completion event.
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/architecture/ADR-002-ai-streaming.md
+git commit -m "docs: add ADR-002 AI streaming decision record (#<issue-number>)"
+```
+
+---
+
+## Task 8: Write ADR-003 — Message Threading
+
+**Files:**
+- Create: `docs/architecture/ADR-003-message-threading.md`
+
+- [ ] **Step 1: Create `docs/architecture/ADR-003-message-threading.md`**
+
+```markdown
+# ADR-003: Message Threading — Separate from AI Sessions
+
+**Status:** Accepted
+**Date:** 2026-04-01
+
+---
+
+## Context
+
+The platform has two distinct communication patterns:
+
+1. **AI Chat** — real-time, streaming, ephemeral. A visitor talks directly to Claude. Stored in `ai_session` / `ai_message`.
+2. **Advisor Messaging** — asynchronous, human-reviewed. A visitor sends a message to a human advisor and waits for a reply.
+
+These could have been modeled as a single "conversation" abstraction, or the advisor could have been added as a participant in the AI chat thread.
+
+## Decision
+
+Model advisor messaging as a completely separate entity hierarchy: `MessageThread` and `ThreadMessage`, independent of `AiSession` and `AiMessage`.
+
+A `MessageThread` has:
+- `visitorId` — the visitor who created it
+- `aiSessionId` (nullable) — an optional link to the AI session that prompted the inquiry
+- `subject` — a short description
+- `status` — state machine: `open` → `pending_reply` → `resolved` / `closed`
+
+A `ThreadMessage` has:
+- `senderRole` — either `"visitor"` or `"advisor"`
+- `content` — the message text
+
+## Consequences
+
+**Positive:**
+- Clean separation of concerns — AI chat and human messaging evolve independently
+- No risk of AI responses appearing in human advisor threads or vice versa
+- Status field enables advisor workflow (filter by `open`, sort by `updated_at`)
+- The nullable `aiSessionId` link allows context-passing ("I was talking to the AI about X, here is my follow-up question") without coupling the models
+
+**Negative:**
+- Two separate data models to maintain instead of one unified conversation model
+- Visitors cannot (currently) reference specific AI messages in their advisor thread — only the session as a whole
+
+**Alternatives considered:**
+- Unified conversation model: rejected because it would complicate the AI context window (advisor messages should not be sent to Claude) and the advisor inbox (AI messages should not appear there)
+- Adding advisor as an AI participant: rejected because it conflates human and AI roles in the same message stream
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/architecture/ADR-003-message-threading.md
+git commit -m "docs: add ADR-003 message threading decision record (#<issue-number>)"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- [x] `docs/ARCHITECTURE.md` created as entry point with C4 context, diagram links, ADR links, package structure, and maintenance note
+- [x] All 5 diagrams created as `.mmd` files and embedded inline in `ARCHITECTURE.md`
+- [x] 3 ADRs written covering all three decisions listed in the spec
+- [x] Phase 2 endpoints marked as dashed/pending in the threading workflow diagram
+- [x] No placeholders — all diagrams contain actual Mermaid syntax, all ADRs contain actual content
+
+**Render verification:** All Mermaid diagrams use syntax supported by GitHub's native renderer (no C4 plugin required — `C4Context` is supported natively in GitHub Markdown as of 2023). Verify by viewing `ARCHITECTURE.md` on GitHub after pushing.

--- a/docs/superpowers/plans/2026-04-01-openapi-codegen-migration.md
+++ b/docs/superpowers/plans/2026-04-01-openapi-codegen-migration.md
@@ -1,0 +1,1395 @@
+# OpenAPI Spec-First Codegen & Controller Migration — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Wire `openapi-generator-maven-plugin` for three domain specs, migrate Phase 1 hand-written controllers to the generated delegate pattern, and expose Swagger UI grouped by domain.
+
+**Architecture:** Each OpenAPI YAML spec in `src/main/resources/api/` drives code generation into `target/generated-sources/openapi`. Generated controllers delegate to hand-written `*ApiDelegate` implementations in `com.advisorplatform.api`. Existing controllers are deleted once delegates are verified.
+
+**Tech Stack:** `openapi-generator-maven-plugin` 7.10.0, `springdoc-openapi-starter-webmvc-ui` 2.8.5, Spring Boot 3.4.3, JaCoCo (managed by Spring Boot parent).
+
+---
+
+## File Map
+
+**Create:**
+- `src/main/resources/api/visitor-session-api.yaml`
+- `src/main/resources/api/ai-chat-api.yaml`
+- `src/main/resources/api/messaging-api.yaml`
+- `src/main/resources/api/advisor-api.yaml` (placeholder)
+- `src/main/java/com/advisorplatform/api/VisitorSessionDelegate.java`
+- `src/main/java/com/advisorplatform/api/AiChatDelegate.java`
+- `src/main/java/com/advisorplatform/api/MessagingDelegate.java`
+- `src/main/java/com/advisorplatform/config/SwaggerConfig.java`
+- `src/test/java/com/advisorplatform/api/VisitorSessionControllerTest.java`
+- `src/test/java/com/advisorplatform/api/AiChatControllerTest.java`
+- `src/test/java/com/advisorplatform/api/MessagingControllerTest.java`
+- `docs/api/visitor-session-api.yaml`
+- `docs/api/ai-chat-api.yaml`
+- `docs/api/messaging-api.yaml`
+
+**Modify:**
+- `pom.xml` — add plugin, springdoc dep, jacoco config
+
+**Delete:**
+- `src/main/java/com/advisorplatform/api/ChatController.java`
+- `src/main/java/com/advisorplatform/api/MessageController.java`
+- `src/test/java/com/advisorplatform/api/ChatControllerTest.java`
+- `src/test/java/com/advisorplatform/api/MessageControllerTest.java`
+
+**Never edit:**
+- `target/generated-sources/openapi/**` — regenerated on every `mvn compile`
+
+---
+
+## Task 1: Bootstrap — Add Codegen Plugin and Springdoc to pom.xml
+
+**Files:**
+- Modify: `pom.xml`
+
+The plugin must be configured before specs are written. All three spec executions are added here so the build structure is stable. Specs are created in the next task.
+
+Note on package layout: each spec gets its own sub-package under `com.advisorplatform.generated.*` to prevent class-name collisions between specs (e.g. both might want a model named `ErrorResponse`). All output goes to `target/generated-sources/openapi`, which the plugin auto-adds as a compile source root.
+
+- [ ] **Step 1: Add springdoc and openapi-generator-maven-plugin to pom.xml**
+
+In `pom.xml`, add the springdoc dependency inside `<dependencies>`:
+
+```xml
+<!-- Swagger UI -->
+<dependency>
+    <groupId>org.springdoc</groupId>
+    <artifactId>springdoc-openapi-starter-webmvc-ui</artifactId>
+    <version>2.8.5</version>
+</dependency>
+```
+
+Add the codegen plugin and jacoco plugin inside `<build><plugins>`:
+
+```xml
+<!-- OpenAPI codegen -->
+<plugin>
+    <groupId>org.openapitools</groupId>
+    <artifactId>openapi-generator-maven-plugin</artifactId>
+    <version>7.10.0</version>
+    <executions>
+        <execution>
+            <id>visitor-session</id>
+            <goals><goal>generate</goal></goals>
+            <configuration>
+                <inputSpec>${project.basedir}/src/main/resources/api/visitor-session-api.yaml</inputSpec>
+                <generatorName>spring</generatorName>
+                <output>${project.build.directory}/generated-sources/openapi</output>
+                <apiPackage>com.advisorplatform.generated.visitorsession.api</apiPackage>
+                <modelPackage>com.advisorplatform.generated.visitorsession.model</modelPackage>
+                <generateApiTests>false</generateApiTests>
+                <generateModelTests>false</generateModelTests>
+                <generateApiDocumentation>false</generateApiDocumentation>
+                <generateModelDocumentation>false</generateModelDocumentation>
+                <configOptions>
+                    <delegatePattern>true</delegatePattern>
+                    <useSpringBoot3>true</useSpringBoot3>
+                    <useLombokAnnotations>true</useLombokAnnotations>
+                    <useTags>true</useTags>
+                    <openApiNullable>false</openApiNullable>
+                </configOptions>
+            </configuration>
+        </execution>
+        <execution>
+            <id>ai-chat</id>
+            <goals><goal>generate</goal></goals>
+            <configuration>
+                <inputSpec>${project.basedir}/src/main/resources/api/ai-chat-api.yaml</inputSpec>
+                <generatorName>spring</generatorName>
+                <output>${project.build.directory}/generated-sources/openapi</output>
+                <apiPackage>com.advisorplatform.generated.aichat.api</apiPackage>
+                <modelPackage>com.advisorplatform.generated.aichat.model</modelPackage>
+                <generateApiTests>false</generateApiTests>
+                <generateModelTests>false</generateModelTests>
+                <generateApiDocumentation>false</generateApiDocumentation>
+                <generateModelDocumentation>false</generateModelDocumentation>
+                <configOptions>
+                    <delegatePattern>true</delegatePattern>
+                    <useSpringBoot3>true</useSpringBoot3>
+                    <useLombokAnnotations>true</useLombokAnnotations>
+                    <useTags>true</useTags>
+                    <openApiNullable>false</openApiNullable>
+                </configOptions>
+            </configuration>
+        </execution>
+        <execution>
+            <id>messaging</id>
+            <goals><goal>generate</goal></goals>
+            <configuration>
+                <inputSpec>${project.basedir}/src/main/resources/api/messaging-api.yaml</inputSpec>
+                <generatorName>spring</generatorName>
+                <output>${project.build.directory}/generated-sources/openapi</output>
+                <apiPackage>com.advisorplatform.generated.messaging.api</apiPackage>
+                <modelPackage>com.advisorplatform.generated.messaging.model</modelPackage>
+                <generateApiTests>false</generateApiTests>
+                <generateModelTests>false</generateModelTests>
+                <generateApiDocumentation>false</generateApiDocumentation>
+                <generateModelDocumentation>false</generateModelDocumentation>
+                <configOptions>
+                    <delegatePattern>true</delegatePattern>
+                    <useSpringBoot3>true</useSpringBoot3>
+                    <useLombokAnnotations>true</useLombokAnnotations>
+                    <useTags>true</useTags>
+                    <openApiNullable>false</openApiNullable>
+                </configOptions>
+            </configuration>
+        </execution>
+        <execution>
+            <id>advisor</id>
+            <goals><goal>generate</goal></goals>
+            <configuration>
+                <inputSpec>${project.basedir}/src/main/resources/api/advisor-api.yaml</inputSpec>
+                <generatorName>spring</generatorName>
+                <output>${project.build.directory}/generated-sources/openapi</output>
+                <apiPackage>com.advisorplatform.generated.advisor.api</apiPackage>
+                <modelPackage>com.advisorplatform.generated.advisor.model</modelPackage>
+                <generateApiTests>false</generateApiTests>
+                <generateModelTests>false</generateModelTests>
+                <generateApiDocumentation>false</generateApiDocumentation>
+                <generateModelDocumentation>false</generateModelDocumentation>
+                <configOptions>
+                    <delegatePattern>true</delegatePattern>
+                    <useSpringBoot3>true</useSpringBoot3>
+                    <useLombokAnnotations>true</useLombokAnnotations>
+                    <useTags>true</useTags>
+                    <openApiNullable>false</openApiNullable>
+                </configOptions>
+            </configuration>
+        </execution>
+    </executions>
+</plugin>
+
+<!-- Code coverage — exclude generated sources -->
+<plugin>
+    <groupId>org.jacoco</groupId>
+    <artifactId>jacoco-maven-plugin</artifactId>
+    <executions>
+        <execution>
+            <goals><goal>prepare-agent</goal></goals>
+        </execution>
+        <execution>
+            <id>report</id>
+            <phase>test</phase>
+            <goals><goal>report</goal></goals>
+        </execution>
+    </executions>
+    <configuration>
+        <excludes>
+            <exclude>com/advisorplatform/generated/**</exclude>
+        </excludes>
+    </configuration>
+</plugin>
+```
+
+The build will fail until the 4 spec YAML files exist. That happens in Task 2.
+
+- [ ] **Step 2: Commit the pom.xml changes**
+
+```bash
+git add pom.xml
+git commit -m "build: add openapi-generator-maven-plugin, springdoc, and jacoco config"
+```
+
+---
+
+## Task 2: Write All Four OpenAPI Specs
+
+**Files:**
+- Create: `src/main/resources/api/visitor-session-api.yaml`
+- Create: `src/main/resources/api/ai-chat-api.yaml`
+- Create: `src/main/resources/api/messaging-api.yaml`
+- Create: `src/main/resources/api/advisor-api.yaml`
+
+These specs reverse-engineer the existing endpoints exactly — same paths, same request/response shapes, same field names. Do not redesign the API while writing specs.
+
+- [ ] **Step 1: Create `src/main/resources/api/visitor-session-api.yaml`**
+
+```yaml
+openapi: 3.0.3
+info:
+  title: Visitor Session API
+  description: Visitor identity and AI planning session lifecycle
+  version: 1.0.0
+tags:
+  - name: VisitorSession
+    description: Visitor identification and session management
+paths:
+  /api/visitor/identify:
+    post:
+      tags: [VisitorSession]
+      summary: Find or create a visitor by browser token
+      operationId: identify
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/IdentifyRequest'
+      responses:
+        '200':
+          description: Visitor identified
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/VisitorResponse'
+        '400':
+          description: Validation error
+  /api/session:
+    post:
+      tags: [VisitorSession]
+      summary: Create a new AI planning session
+      operationId: createSession
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateSessionRequest'
+      responses:
+        '200':
+          description: Session created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SessionResponse'
+        '400':
+          description: Validation error or visitor not found
+  /api/visitor/{visitorId}/sessions:
+    get:
+      tags: [VisitorSession]
+      summary: List sessions for a visitor
+      operationId: getSessions
+      parameters:
+        - name: visitorId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Session list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/SessionResponse'
+components:
+  schemas:
+    IdentifyRequest:
+      type: object
+      required: [browserToken]
+      properties:
+        browserToken:
+          type: string
+          minLength: 1
+    VisitorResponse:
+      type: object
+      properties:
+        visitorId:
+          type: string
+          format: uuid
+        browserToken:
+          type: string
+    CreateSessionRequest:
+      type: object
+      required: [visitorId]
+      properties:
+        visitorId:
+          type: string
+          format: uuid
+    SessionResponse:
+      type: object
+      properties:
+        sessionId:
+          type: string
+          format: uuid
+        createdAt:
+          type: string
+```
+
+- [ ] **Step 2: Create `src/main/resources/api/ai-chat-api.yaml`**
+
+```yaml
+openapi: 3.0.3
+info:
+  title: AI Chat API
+  description: AI-powered planning chat endpoints (streaming and non-streaming)
+  version: 1.0.0
+tags:
+  - name: AiChat
+    description: AI chat with Claude
+paths:
+  /api/chat/{sessionId}:
+    post:
+      tags: [AiChat]
+      summary: Non-streaming chat (blocking)
+      operationId: chat
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatRequest'
+      responses:
+        '200':
+          description: Assistant response
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ChatResponse'
+        '400':
+          description: Validation error or session not found
+  /api/chat/{sessionId}/stream:
+    post:
+      tags: [AiChat]
+      summary: Streaming SSE chat
+      operationId: streamChat
+      parameters:
+        - name: sessionId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/ChatRequest'
+      responses:
+        '200':
+          description: Server-sent event stream of text tokens
+          content:
+            text/event-stream:
+              schema:
+                type: string
+components:
+  schemas:
+    ChatRequest:
+      type: object
+      required: [message]
+      properties:
+        message:
+          type: string
+          minLength: 1
+    ChatResponse:
+      type: object
+      properties:
+        messageId:
+          type: string
+          format: uuid
+        content:
+          type: string
+        model:
+          type: string
+        createdAt:
+          type: string
+```
+
+- [ ] **Step 3: Create `src/main/resources/api/messaging-api.yaml`**
+
+```yaml
+openapi: 3.0.3
+info:
+  title: Messaging API
+  description: Visitor-to-advisor message threading
+  version: 1.0.0
+tags:
+  - name: Messaging
+    description: Message thread management
+paths:
+  /api/message:
+    post:
+      tags: [Messaging]
+      summary: Create a new message thread with initial visitor message
+      operationId: createThread
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateThreadRequest'
+      responses:
+        '200':
+          description: Thread created
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CreateThreadResponse'
+        '400':
+          description: Validation error or visitor not found
+  /api/visitor/{visitorId}/threads:
+    get:
+      tags: [Messaging]
+      summary: List all threads for a visitor
+      operationId: getThreads
+      parameters:
+        - name: visitorId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Thread list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ThreadSummary'
+  /api/thread/{threadId}/messages:
+    get:
+      tags: [Messaging]
+      summary: List all messages in a thread
+      operationId: getMessages
+      parameters:
+        - name: threadId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '200':
+          description: Message list
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/MessageSummary'
+    post:
+      tags: [Messaging]
+      summary: Add a visitor follow-up message to a thread
+      operationId: addMessage
+      parameters:
+        - name: threadId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/AddMessageRequest'
+      responses:
+        '200':
+          description: Message added
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/AddMessageResponse'
+        '400':
+          description: Validation error or thread not found
+components:
+  schemas:
+    CreateThreadRequest:
+      type: object
+      required: [visitorId, content]
+      properties:
+        visitorId:
+          type: string
+          format: uuid
+        aiSessionId:
+          type: string
+          format: uuid
+          nullable: true
+        subject:
+          type: string
+        content:
+          type: string
+          minLength: 1
+    CreateThreadResponse:
+      type: object
+      properties:
+        threadId:
+          type: string
+          format: uuid
+    ThreadSummary:
+      type: object
+      properties:
+        threadId:
+          type: string
+          format: uuid
+        subject:
+          type: string
+        status:
+          type: string
+        updatedAt:
+          type: string
+    MessageSummary:
+      type: object
+      properties:
+        messageId:
+          type: string
+          format: uuid
+        senderRole:
+          type: string
+        content:
+          type: string
+        createdAt:
+          type: string
+    AddMessageRequest:
+      type: object
+      required: [content]
+      properties:
+        content:
+          type: string
+          minLength: 1
+    AddMessageResponse:
+      type: object
+      properties:
+        messageId:
+          type: string
+          format: uuid
+```
+
+- [ ] **Step 4: Create `src/main/resources/api/advisor-api.yaml` (placeholder)**
+
+```yaml
+openapi: 3.0.3
+info:
+  title: Advisor API
+  description: Advisor-facing endpoints — Phase 2
+  version: 0.1.0
+tags:
+  - name: Advisor
+    description: Advisor operations (not yet implemented)
+paths: {}
+```
+
+- [ ] **Step 5: Verify the build compiles and generates sources**
+
+```bash
+mvn compile -q
+```
+
+Expected: BUILD SUCCESS with no errors. Then verify:
+
+```bash
+ls target/generated-sources/openapi/com/advisorplatform/generated/
+```
+
+Expected output (4 subdirectories):
+```
+aichat/  advisor/  messaging/  visitorsession/
+```
+
+Each contains `api/` and `model/` packages with generated classes.
+
+- [ ] **Step 6: Check generated delegate interface names** (used in Tasks 3 and 4)
+
+```bash
+find target/generated-sources/openapi -name "*ApiDelegate.java" | sort
+```
+
+Expected:
+```
+.../aichat/api/AiChatApiDelegate.java
+.../advisor/api/AdvisorApiDelegate.java
+.../messaging/api/MessagingApiDelegate.java
+.../visitorsession/api/VisitorSessionApiDelegate.java
+```
+
+If names differ from expected, update delegate class names in Tasks 3 and 4 accordingly.
+
+- [ ] **Step 7: Commit specs**
+
+```bash
+git add src/main/resources/api/
+git commit -m "feat: add OpenAPI specs for visitor-session, ai-chat, messaging, and advisor domains"
+```
+
+---
+
+## Task 3: Implement VisitorSessionDelegate + AiChatDelegate, Delete ChatController
+
+**Files:**
+- Create: `src/main/java/com/advisorplatform/api/VisitorSessionDelegate.java`
+- Create: `src/main/java/com/advisorplatform/api/AiChatDelegate.java`
+- Create: `src/test/java/com/advisorplatform/api/VisitorSessionControllerTest.java`
+- Create: `src/test/java/com/advisorplatform/api/AiChatControllerTest.java`
+- Delete: `src/main/java/com/advisorplatform/api/ChatController.java`
+- Delete: `src/test/java/com/advisorplatform/api/ChatControllerTest.java`
+
+**Important:** `ChatController` handles both visitor-session AND chat endpoints. Both delegates must be created before the controller is deleted, or the build will break.
+
+The generated controller for `VisitorSession` tag is `VisitorSessionApiController` in `com.advisorplatform.generated.visitorsession.api`. The `@WebMvcTest` tests import it and also `@Import` the delegate so Spring can wire it.
+
+- [ ] **Step 1: Write `VisitorSessionDelegate.java`**
+
+```java
+package com.advisorplatform.api;
+
+import com.advisorplatform.generated.visitorsession.api.VisitorSessionApiDelegate;
+import com.advisorplatform.generated.visitorsession.model.CreateSessionRequest;
+import com.advisorplatform.generated.visitorsession.model.IdentifyRequest;
+import com.advisorplatform.generated.visitorsession.model.SessionResponse;
+import com.advisorplatform.generated.visitorsession.model.VisitorResponse;
+import com.advisorplatform.service.VisitorService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class VisitorSessionDelegate implements VisitorSessionApiDelegate {
+
+    private final VisitorService visitorService;
+
+    public VisitorSessionDelegate(VisitorService visitorService) {
+        this.visitorService = visitorService;
+    }
+
+    @Override
+    public ResponseEntity<VisitorResponse> identify(IdentifyRequest request) {
+        var visitor = visitorService.findOrCreate(request.getBrowserToken());
+        var response = new VisitorResponse();
+        response.setVisitorId(visitor.getId());
+        response.setBrowserToken(visitor.getBrowserToken());
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<SessionResponse> createSession(CreateSessionRequest request) {
+        var session = visitorService.createSession(request.getVisitorId());
+        var response = new SessionResponse();
+        response.setSessionId(session.getId());
+        response.setCreatedAt(session.getCreatedAt().toString());
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<List<SessionResponse>> getSessions(UUID visitorId) {
+        var sessions = visitorService.getSessions(visitorId).stream()
+                .map(s -> {
+                    var r = new SessionResponse();
+                    r.setSessionId(s.getId());
+                    r.setCreatedAt(s.getCreatedAt().toString());
+                    return r;
+                })
+                .toList();
+        return ResponseEntity.ok(sessions);
+    }
+}
+```
+
+- [ ] **Step 2: Write `AiChatDelegate.java`**
+
+The `streamChat` endpoint returns `Flux<String>` with SSE content type. The generated delegate interface returns `ResponseEntity<Void>` for streaming by default — override the controller method directly instead of using the delegate for the stream endpoint. Check the generated `AiChatApiDelegate` interface:
+
+```bash
+cat target/generated-sources/openapi/com/advisorplatform/generated/aichat/api/AiChatApiDelegate.java
+```
+
+Write the delegate matching the generated method signatures:
+
+```java
+package com.advisorplatform.api;
+
+import com.advisorplatform.ai.PlannerAiService;
+import com.advisorplatform.domain.entity.AiMessage;
+import com.advisorplatform.generated.aichat.api.AiChatApiDelegate;
+import com.advisorplatform.generated.aichat.model.ChatRequest;
+import com.advisorplatform.generated.aichat.model.ChatResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import reactor.core.publisher.Flux;
+
+import java.util.UUID;
+
+@Component
+public class AiChatDelegate implements AiChatApiDelegate {
+
+    private final PlannerAiService plannerAiService;
+
+    public AiChatDelegate(PlannerAiService plannerAiService) {
+        this.plannerAiService = plannerAiService;
+    }
+
+    @Override
+    public ResponseEntity<ChatResponse> chat(UUID sessionId, ChatRequest request) {
+        AiMessage message = plannerAiService.chat(sessionId, request.getMessage());
+        var response = new ChatResponse();
+        response.setMessageId(message.getId());
+        response.setContent(message.getContent());
+        response.setModel(message.getModelVersion());
+        response.setCreatedAt(message.getCreatedAt().toString());
+        return ResponseEntity.ok(response);
+    }
+}
+```
+
+**Note on `streamChat`:** The openapi-generator spring delegate pattern does not handle reactive `Flux` returns well for SSE. After writing the above, check the generated `AiChatApiDelegate` interface to see what `streamChat` signature it generates. If it returns `ResponseEntity<Void>` or similar, you will need a custom `@RestController` for the stream endpoint instead of using the delegate for it. Add a minimal `AiChatStreamController.java`:
+
+```java
+package com.advisorplatform.api;
+
+import com.advisorplatform.ai.PlannerAiService;
+import com.advisorplatform.generated.aichat.model.ChatRequest;
+import jakarta.validation.Valid;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.*;
+import reactor.core.publisher.Flux;
+
+import java.util.UUID;
+
+@RestController
+@RequestMapping("/api/chat")
+public class AiChatStreamController {
+
+    private final PlannerAiService plannerAiService;
+
+    public AiChatStreamController(PlannerAiService plannerAiService) {
+        this.plannerAiService = plannerAiService;
+    }
+
+    @PostMapping(value = "/{sessionId}/stream", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public Flux<String> streamChat(
+            @PathVariable UUID sessionId,
+            @Valid @RequestBody ChatRequest request) {
+        return plannerAiService.streamChat(sessionId, request.getMessage());
+    }
+}
+```
+
+If the generated delegate interface already handles Flux properly, skip `AiChatStreamController` and implement the stream method in `AiChatDelegate` instead.
+
+- [ ] **Step 3: Verify it compiles**
+
+```bash
+mvn compile -q
+```
+
+Expected: BUILD SUCCESS. Fix any import or signature mismatch errors before continuing.
+
+- [ ] **Step 4: Write `VisitorSessionControllerTest.java`**
+
+This test replaces the visitor-session portion of `ChatControllerTest`. It targets the generated controller class and imports the hand-written delegate.
+
+```java
+package com.advisorplatform.api;
+
+import com.advisorplatform.domain.entity.AiSession;
+import com.advisorplatform.domain.entity.Visitor;
+import com.advisorplatform.generated.visitorsession.api.VisitorSessionApiController;
+import com.advisorplatform.service.VisitorService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = VisitorSessionApiController.class)
+@Import(VisitorSessionDelegate.class)
+@TestPropertySource(properties = "spring.ai.anthropic.api-key=test-key")
+class VisitorSessionControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean VisitorService visitorService;
+
+    @Test
+    void identify_validToken_returns200WithVisitorIdAndToken() throws Exception {
+        UUID visitorId = UUID.randomUUID();
+        Visitor visitor = new Visitor();
+        ReflectionTestUtils.setField(visitor, "id", visitorId);
+        visitor.setBrowserToken("token-abc");
+        when(visitorService.findOrCreate("token-abc")).thenReturn(visitor);
+
+        mockMvc.perform(post("/api/visitor/identify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"browserToken\":\"token-abc\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.visitorId").value(visitorId.toString()))
+                .andExpect(jsonPath("$.browserToken").value("token-abc"));
+    }
+
+    @Test
+    void identify_blankToken_returns400() throws Exception {
+        mockMvc.perform(post("/api/visitor/identify")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"browserToken\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createSession_validVisitorId_returns200WithSessionId() throws Exception {
+        UUID visitorId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        AiSession session = new AiSession();
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        ReflectionTestUtils.setField(session, "createdAt", Instant.parse("2026-03-28T10:00:00Z"));
+        when(visitorService.createSession(eq(visitorId))).thenReturn(session);
+
+        mockMvc.perform(post("/api/session")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"visitorId\":\"" + visitorId + "\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.sessionId").value(sessionId.toString()));
+    }
+
+    @Test
+    void createSession_serviceThrowsIllegalArgument_returns400() throws Exception {
+        when(visitorService.createSession(any()))
+                .thenThrow(new IllegalArgumentException("Visitor not found: some-id"));
+
+        mockMvc.perform(post("/api/session")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"visitorId\":\"" + UUID.randomUUID() + "\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createSession_nullVisitorId_returns400() throws Exception {
+        mockMvc.perform(post("/api/session")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"visitorId\":null}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getSessions_returns200WithList() throws Exception {
+        UUID visitorId = UUID.randomUUID();
+        UUID sessionId = UUID.randomUUID();
+        AiSession session = new AiSession();
+        ReflectionTestUtils.setField(session, "id", sessionId);
+        ReflectionTestUtils.setField(session, "createdAt", Instant.parse("2026-03-28T10:00:00Z"));
+        when(visitorService.getSessions(visitorId)).thenReturn(List.of(session));
+
+        mockMvc.perform(get("/api/visitor/{visitorId}/sessions", visitorId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].sessionId").value(sessionId.toString()));
+    }
+}
+```
+
+- [ ] **Step 5: Write `AiChatControllerTest.java`**
+
+```java
+package com.advisorplatform.api;
+
+import com.advisorplatform.ai.PlannerAiService;
+import com.advisorplatform.domain.entity.AiMessage;
+import com.advisorplatform.domain.entity.AiSession;
+import com.advisorplatform.generated.aichat.api.AiChatApiController;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+import reactor.core.publisher.Flux;
+
+import java.time.Instant;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = {AiChatApiController.class, AiChatStreamController.class})
+@Import(AiChatDelegate.class)
+@TestPropertySource(properties = "spring.ai.anthropic.api-key=test-key")
+class AiChatControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean PlannerAiService plannerAiService;
+
+    @Test
+    void chat_validRequest_returns200WithAssistantMessage() throws Exception {
+        UUID sessionId = UUID.randomUUID();
+        AiMessage response = AiMessage.assistantMessage(new AiSession(), "AI reply", "claude-3", 100, 250);
+        ReflectionTestUtils.setField(response, "id", UUID.randomUUID());
+        ReflectionTestUtils.setField(response, "createdAt", Instant.parse("2026-03-28T10:00:00Z"));
+        when(plannerAiService.chat(eq(sessionId), eq("Hello"))).thenReturn(response);
+
+        mockMvc.perform(post("/api/chat/{sessionId}", sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"Hello\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.content").value("AI reply"))
+                .andExpect(jsonPath("$.model").value("claude-3"));
+    }
+
+    @Test
+    void chat_blankMessage_returns400() throws Exception {
+        mockMvc.perform(post("/api/chat/{sessionId}", UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void streamChat_validRequest_returnsEventStreamStatus200() throws Exception {
+        UUID sessionId = UUID.randomUUID();
+        when(plannerAiService.streamChat(eq(sessionId), eq("Hi"))).thenReturn(Flux.just("chunk1", "chunk2"));
+
+        mockMvc.perform(post("/api/chat/{sessionId}/stream", sessionId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"message\":\"Hi\"}"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_EVENT_STREAM));
+    }
+}
+```
+
+- [ ] **Step 6: Run the new tests to verify they pass before deleting the old controller**
+
+```bash
+mvn test -pl . -Dtest="VisitorSessionControllerTest,AiChatControllerTest" -q
+```
+
+Expected: Both test classes pass. If any test fails, fix before proceeding.
+
+- [ ] **Step 7: Delete `ChatController.java` and `ChatControllerTest.java`**
+
+```bash
+rm src/main/java/com/advisorplatform/api/ChatController.java
+rm src/test/java/com/advisorplatform/api/ChatControllerTest.java
+```
+
+- [ ] **Step 8: Run full test suite**
+
+```bash
+mvn test -q
+```
+
+Expected: All tests pass (the count will be the same as before since old tests were replaced 1:1). If tests fail, check for leftover imports referencing `ChatController`.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/main/java/com/advisorplatform/api/ src/test/java/com/advisorplatform/api/
+git commit -m "feat: migrate ChatController to VisitorSessionDelegate and AiChatDelegate (#<issue-number>)"
+```
+
+---
+
+## Task 4: Implement MessagingDelegate, Delete MessageController
+
+**Files:**
+- Create: `src/main/java/com/advisorplatform/api/MessagingDelegate.java`
+- Create: `src/test/java/com/advisorplatform/api/MessagingControllerTest.java`
+- Delete: `src/main/java/com/advisorplatform/api/MessageController.java`
+- Delete: `src/test/java/com/advisorplatform/api/MessageControllerTest.java`
+
+- [ ] **Step 1: Write `MessagingDelegate.java`**
+
+```java
+package com.advisorplatform.api;
+
+import com.advisorplatform.generated.messaging.api.MessagingApiDelegate;
+import com.advisorplatform.generated.messaging.model.*;
+import com.advisorplatform.service.MessageService;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.UUID;
+
+@Component
+public class MessagingDelegate implements MessagingApiDelegate {
+
+    private final MessageService messageService;
+
+    public MessagingDelegate(MessageService messageService) {
+        this.messageService = messageService;
+    }
+
+    @Override
+    public ResponseEntity<CreateThreadResponse> createThread(CreateThreadRequest request) {
+        var thread = messageService.createThread(
+                request.getVisitorId(),
+                request.getAiSessionId(),
+                request.getSubject(),
+                request.getContent());
+        var response = new CreateThreadResponse();
+        response.setThreadId(thread.getId());
+        return ResponseEntity.ok(response);
+    }
+
+    @Override
+    public ResponseEntity<List<ThreadSummary>> getThreads(UUID visitorId) {
+        var summaries = messageService.getThreads(visitorId).stream()
+                .map(t -> {
+                    var s = new ThreadSummary();
+                    s.setThreadId(t.getId());
+                    s.setSubject(t.getSubject());
+                    s.setStatus(t.getStatus());
+                    s.setUpdatedAt(t.getUpdatedAt().toString());
+                    return s;
+                })
+                .toList();
+        return ResponseEntity.ok(summaries);
+    }
+
+    @Override
+    public ResponseEntity<List<MessageSummary>> getMessages(UUID threadId) {
+        var summaries = messageService.getMessages(threadId).stream()
+                .map(m -> {
+                    var s = new MessageSummary();
+                    s.setMessageId(m.getId());
+                    s.setSenderRole(m.getSenderRole());
+                    s.setContent(m.getContent());
+                    s.setCreatedAt(m.getCreatedAt().toString());
+                    return s;
+                })
+                .toList();
+        return ResponseEntity.ok(summaries);
+    }
+
+    @Override
+    public ResponseEntity<AddMessageResponse> addMessage(UUID threadId, AddMessageRequest request) {
+        var message = messageService.addMessage(threadId, request.getContent());
+        var response = new AddMessageResponse();
+        response.setMessageId(message.getId());
+        return ResponseEntity.ok(response);
+    }
+}
+```
+
+- [ ] **Step 2: Write `MessagingControllerTest.java`**
+
+```java
+package com.advisorplatform.api;
+
+import com.advisorplatform.domain.entity.MessageThread;
+import com.advisorplatform.domain.entity.ThreadMessage;
+import com.advisorplatform.domain.entity.Visitor;
+import com.advisorplatform.generated.messaging.api.MessagingApiController;
+import com.advisorplatform.service.MessageService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+@WebMvcTest(controllers = MessagingApiController.class)
+@Import(MessagingDelegate.class)
+@TestPropertySource(properties = "spring.ai.anthropic.api-key=test-key")
+class MessagingControllerTest {
+
+    @Autowired MockMvc mockMvc;
+    @MockBean MessageService messageService;
+
+    @Test
+    void createThread_validRequest_returns200WithThreadId() throws Exception {
+        UUID visitorId = UUID.randomUUID();
+        UUID threadId = UUID.randomUUID();
+        Visitor visitor = new Visitor();
+        MessageThread thread = MessageThread.builder().visitor(visitor).subject("Help me").build();
+        ReflectionTestUtils.setField(thread, "id", threadId);
+        when(messageService.createThread(eq(visitorId), isNull(), eq("Help me"), eq("First message")))
+                .thenReturn(thread);
+
+        mockMvc.perform(post("/api/message")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"visitorId\":\"" + visitorId + "\","
+                                + "\"subject\":\"Help me\","
+                                + "\"content\":\"First message\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.threadId").value(threadId.toString()));
+    }
+
+    @Test
+    void createThread_blankContent_returns400() throws Exception {
+        mockMvc.perform(post("/api/message")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"visitorId\":\"" + UUID.randomUUID() + "\","
+                                + "\"content\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createThread_serviceThrowsIllegalArgument_returns400() throws Exception {
+        when(messageService.createThread(any(), any(), any(), any()))
+                .thenThrow(new IllegalArgumentException("Visitor not found: some-id"));
+
+        mockMvc.perform(post("/api/message")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"visitorId\":\"" + UUID.randomUUID() + "\","
+                                + "\"content\":\"Hello\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void createThread_nullVisitorId_returns400() throws Exception {
+        mockMvc.perform(post("/api/message")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"visitorId\":null,\"content\":\"Hello\"}"))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    void getThreads_validVisitorId_returns200WithList() throws Exception {
+        UUID visitorId = UUID.randomUUID();
+        UUID threadId = UUID.randomUUID();
+        Visitor visitor = new Visitor();
+        MessageThread thread = MessageThread.builder().visitor(visitor).subject("My question").build();
+        ReflectionTestUtils.setField(thread, "id", threadId);
+        ReflectionTestUtils.setField(thread, "updatedAt", Instant.parse("2026-03-28T10:00:00Z"));
+        when(messageService.getThreads(visitorId)).thenReturn(List.of(thread));
+
+        mockMvc.perform(get("/api/visitor/{visitorId}/threads", visitorId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].threadId").value(threadId.toString()))
+                .andExpect(jsonPath("$[0].subject").value("My question"))
+                .andExpect(jsonPath("$[0].status").value("open"));
+    }
+
+    @Test
+    void getMessages_validThreadId_returns200WithList() throws Exception {
+        UUID threadId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        Visitor visitor = new Visitor();
+        MessageThread thread = MessageThread.builder().visitor(visitor).build();
+        ThreadMessage message = ThreadMessage.builder()
+                .thread(thread).senderRole("visitor").content("Hello").build();
+        ReflectionTestUtils.setField(message, "id", messageId);
+        ReflectionTestUtils.setField(message, "createdAt", Instant.parse("2026-03-28T10:00:00Z"));
+        when(messageService.getMessages(threadId)).thenReturn(List.of(message));
+
+        mockMvc.perform(get("/api/thread/{threadId}/messages", threadId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].messageId").value(messageId.toString()))
+                .andExpect(jsonPath("$[0].senderRole").value("visitor"))
+                .andExpect(jsonPath("$[0].content").value("Hello"));
+    }
+
+    @Test
+    void addMessage_validContent_returns200WithMessageId() throws Exception {
+        UUID threadId = UUID.randomUUID();
+        UUID messageId = UUID.randomUUID();
+        ThreadMessage message = ThreadMessage.builder()
+                .thread(MessageThread.builder().visitor(new Visitor()).build())
+                .senderRole("visitor")
+                .content("Follow up question")
+                .build();
+        ReflectionTestUtils.setField(message, "id", messageId);
+        when(messageService.addMessage(eq(threadId), eq("Follow up question"))).thenReturn(message);
+
+        mockMvc.perform(post("/api/thread/{threadId}/messages", threadId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"Follow up question\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.messageId").value(messageId.toString()));
+    }
+
+    @Test
+    void addMessage_blankContent_returns400() throws Exception {
+        mockMvc.perform(post("/api/thread/{threadId}/messages", UUID.randomUUID())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"content\":\"\"}"))
+                .andExpect(status().isBadRequest());
+    }
+}
+```
+
+- [ ] **Step 3: Run new tests before deleting old controller**
+
+```bash
+mvn test -pl . -Dtest="MessagingControllerTest" -q
+```
+
+Expected: All 8 tests pass.
+
+- [ ] **Step 4: Delete `MessageController.java` and `MessageControllerTest.java`**
+
+```bash
+rm src/main/java/com/advisorplatform/api/MessageController.java
+rm src/test/java/com/advisorplatform/api/MessageControllerTest.java
+```
+
+- [ ] **Step 5: Run full test suite**
+
+```bash
+mvn test -q
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/main/java/com/advisorplatform/api/ src/test/java/com/advisorplatform/api/
+git commit -m "feat: migrate MessageController to MessagingDelegate (#<issue-number>)"
+```
+
+---
+
+## Task 5: Add Swagger UI Configuration
+
+**Files:**
+- Create: `src/main/java/com/advisorplatform/config/SwaggerConfig.java`
+
+- [ ] **Step 1: Write `SwaggerConfig.java`**
+
+```java
+package com.advisorplatform.config;
+
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    @Bean
+    public GroupedOpenApi visitorSessionApi() {
+        return GroupedOpenApi.builder()
+                .group("visitor-session")
+                .pathsToMatch("/api/visitor/**", "/api/session/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi aiChatApi() {
+        return GroupedOpenApi.builder()
+                .group("ai-chat")
+                .pathsToMatch("/api/chat/**")
+                .build();
+    }
+
+    @Bean
+    public GroupedOpenApi messagingApi() {
+        return GroupedOpenApi.builder()
+                .group("messaging")
+                .pathsToMatch("/api/message/**", "/api/thread/**")
+                .build();
+    }
+}
+```
+
+- [ ] **Step 2: Run full test suite**
+
+```bash
+mvn test -q
+```
+
+Expected: All tests pass.
+
+- [ ] **Step 3: Smoke test Swagger UI (requires running app)**
+
+```bash
+mvn spring-boot:run &
+sleep 8
+curl -s http://localhost:8080/swagger-ui.html | grep -c "swagger"
+curl -s "http://localhost:8080/v3/api-docs/groups" | grep -o '"group":"[^"]*"' | sort
+kill %1
+```
+
+Expected second command output (order may vary):
+```
+"group":"ai-chat"
+"group":"messaging"
+"group":"visitor-session"
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/main/java/com/advisorplatform/config/SwaggerConfig.java
+git commit -m "feat: add Swagger UI with grouped API tabs (#<issue-number>)"
+```
+
+---
+
+## Task 6: Export YAML Snapshots to docs/api/
+
+**Files:**
+- Create: `docs/api/visitor-session-api.yaml`
+- Create: `docs/api/ai-chat-api.yaml`
+- Create: `docs/api/messaging-api.yaml`
+
+These are static copies of the spec files for offline review and future TypeScript codegen. They are identical to the source specs in `src/main/resources/api/` — copy them now and keep them in sync as specs evolve.
+
+- [ ] **Step 1: Create the docs/api/ directory and copy specs**
+
+```bash
+mkdir -p docs/api
+cp src/main/resources/api/visitor-session-api.yaml docs/api/
+cp src/main/resources/api/ai-chat-api.yaml docs/api/
+cp src/main/resources/api/messaging-api.yaml docs/api/
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/api/
+git commit -m "docs: export OpenAPI YAML snapshots to docs/api/ (#<issue-number>)"
+```
+
+---
+
+## Self-Review Checklist
+
+**Spec coverage:**
+- [x] openapi-generator-maven-plugin configured with 4 executions
+- [x] springdoc dependency added
+- [x] JaCoCo configured with `com/advisorplatform/generated/**` exclusion
+- [x] `target/` already covered by existing `.gitignore` — no change needed
+- [x] All 3 Phase 1 specs written matching existing endpoints exactly
+- [x] advisor-api.yaml placeholder created
+- [x] VisitorSessionDelegate, AiChatDelegate, MessagingDelegate implemented
+- [x] All old controllers deleted
+- [x] All tests migrated and passing
+- [x] SwaggerConfig with 3 groups
+- [x] docs/api/ snapshots exported
+
+**Known adaptation point:** The `streamChat` endpoint returns `Flux<String>` with SSE content type, which openapi-generator's delegate pattern does not handle natively. Task 3 Step 2 includes conditional logic: check the generated `AiChatApiDelegate` signature and use `AiChatStreamController` if needed. The test in Task 3 Step 5 accounts for both the generated controller and the stream controller in `@WebMvcTest`.

--- a/docs/superpowers/specs/2026-04-01-api-and-arch-docs-design.md
+++ b/docs/superpowers/specs/2026-04-01-api-and-arch-docs-design.md
@@ -1,0 +1,157 @@
+# Design Spec: API Documentation + Architecture Documentation
+**Date:** 2026-04-01
+**Status:** Approved — pending implementation plan
+
+---
+
+## Problem Statement
+
+The codebase has no machine-readable API contracts and no architectural documentation. This creates friction for:
+- Frontend developers consuming the API (no types, no schema)
+- New contributors onboarding to the system
+- Design review and decision traceability
+
+---
+
+## Task A — API Documentation (OpenAPI Spec-First)
+
+### Approach
+
+Introduce `openapi-generator-maven-plugin` to generate Spring controller interfaces and POJOs from OpenAPI 3 YAML specs stored on the classpath. Implement the generated delegate interfaces by hand.
+
+### Spec Storage
+
+All YAML specs live at `src/main/resources/api/`, one file per domain. They are on the classpath and served by springdoc at runtime.
+
+| Domain | Spec File |
+|---|---|
+| Visitor + Session | `visitor-session-api.yaml` |
+| AI Chat | `ai-chat-api.yaml` |
+| Messaging (threads) | `messaging-api.yaml` |
+| Advisor (Phase 2) | `advisor-api.yaml` |
+
+### Codegen Configuration
+
+Plugin: `openapi-generator-maven-plugin`
+Generator: `spring`
+Key options:
+- `delegatePattern: true`
+- `interfaceOnly: true`
+- `useLombokAnnotations: true`
+- `useSpringBoot3: true`
+- Output to `target/generated-sources/openapi`
+
+Generated sources are never edited directly. The Maven build regenerates them on each compile.
+
+### Generated Source Exclusions
+
+**Git:** `target/` is already excluded by `.gitignore` (standard Maven convention). Verify `target/generated-sources/openapi` is covered; add an explicit entry if needed.
+
+**Code coverage:** Configure the JaCoCo Maven plugin to exclude the generated package from coverage calculations. Add exclusion patterns to the `jacoco-maven-plugin` configuration in `pom.xml`:
+```xml
+<exclude>com/advisorplatform/generated/**</exclude>
+```
+The exact package path depends on the `apiPackage` and `modelPackage` codegen options — confirm after first generation and update the exclusion pattern accordingly.
+
+### Delegate Pattern
+
+For each spec, the plugin generates:
+- `{Domain}Api` — Spring MVC interface with `@RequestMapping` annotations
+- `{Domain}ApiDelegate` — delegate interface with default no-op implementations
+- POJOs for all request/response models (Lombok-annotated, not records)
+
+Hand-written delegate implementations live in `src/main/java/com/advisorplatform/api/` and implement `{Domain}ApiDelegate`. The generated controller wires the delegate automatically via constructor injection.
+
+### Migration Path for Phase 1 Controllers
+
+Phase 1 controllers (`ChatController`, `MessageController`, `VisitorController`) were written code-first before this convention existed. The migration approach:
+
+1. Write specs that match the existing endpoints exactly (reverse-engineer, don't redesign)
+2. Generate interfaces from the specs
+3. Extract logic from existing controllers into new `*ApiDelegate` implementations
+4. Delete the hand-written controllers once delegate implementations are verified
+
+This is a one-time migration. All new domains (Phase 2+) start spec-first.
+
+### Swagger UI
+
+Add `springdoc-openapi-starter-webmvc-ui` dependency. Configure `GroupedOpenApi` beans — one per domain — so Swagger UI shows separate tabs at `/swagger-ui.html`.
+
+### Exported Snapshots
+
+After codegen is wired up, export each group's resolved YAML to `docs/api/` for:
+- Offline review
+- TypeScript client codegen (future)
+
+Files: `docs/api/visitor-session-api.yaml`, `docs/api/ai-chat-api.yaml`, `docs/api/messaging-api.yaml`
+
+---
+
+## Task B — Workflow & Architecture Documentation
+
+### Approach
+
+Mermaid diagrams in Markdown files, plus lightweight ADRs. Serves three audiences: onboarding, design review, and living reference.
+
+### Folder Structure
+
+```
+docs/
+├── ARCHITECTURE.md              # Entry point: C4 context + links to all diagrams/ADRs
+├── architecture/
+│   ├── diagrams/
+│   │   ├── c4-context.mmd
+│   │   ├── visitor-session-flow.mmd
+│   │   ├── ai-streaming-pipeline.mmd
+│   │   ├── message-threading-workflow.mmd
+│   │   └── entity-relationships.mmd
+│   ├── ADR-001-session-identity.md
+│   ├── ADR-002-ai-streaming.md
+│   └── ADR-003-message-threading.md
+└── api/                         # Exported OpenAPI YAML snapshots (from Task A)
+```
+
+### Diagrams
+
+| File | Diagram Type | Content |
+|---|---|---|
+| `c4-context.mmd` | C4Context | System boundary: Visitor browser, Advisor browser, Claude API, Postgres |
+| `visitor-session-flow.mmd` | Sequence | `POST /identify` → `POST /session` → `POST /chat/{id}` call chain with persistence |
+| `ai-streaming-pipeline.mmd` | Sequence | SSE streaming: request → Spring AI → Anthropic API → token stream → save AiMessages |
+| `message-threading-workflow.mmd` | Flowchart | Thread state machine: `open` → `pending_reply` → `resolved` / `closed` |
+| `entity-relationships.mmd` | ER | Visitor, AiSession, AiMessage, MessageThread, ThreadMessage and FK relationships |
+
+All `.mmd` files are embedded inline in `ARCHITECTURE.md` using fenced code blocks so they render on GitHub without a separate tool.
+
+### ADRs
+
+Each ADR follows the format: **Status / Context / Decision / Consequences** (~1 page).
+
+| File | Decision Captured |
+|---|---|
+| `ADR-001-session-identity.md` | Why browser token + find-or-create instead of authenticated identity for Phase 1 |
+| `ADR-002-ai-streaming.md` | Why SSE for AI chat; how message persistence is timed relative to the stream |
+| `ADR-003-message-threading.md` | Why message threads are separate from AI sessions; the role + status model |
+
+### Maintenance
+
+Add to PR checklist (in `CLAUDE.md` or a `CONTRIBUTING.md`): "If the API surface or database schema changed, update the relevant diagram and/or ADR."
+
+---
+
+## Out of Scope
+
+- No interactive API explorer beyond Swagger UI
+- No automated diagram rendering pipeline (Mermaid in GitHub Markdown is sufficient)
+- No TypeScript client generation in this task (snapshots in `docs/api/` enable it later)
+- `advisor-api.yaml` spec is created as a placeholder only — no implementation in Phase 1
+
+---
+
+## Success Criteria
+
+- `mvn compile` succeeds with generated sources; no hand-written controllers reference removed classes
+- `/swagger-ui.html` loads with 3 domain tabs (visitor-session, ai-chat, messaging)
+- `docs/ARCHITECTURE.md` renders all 5 diagrams correctly on GitHub
+- 3 ADRs written and linked from `ARCHITECTURE.md`
+- Existing 35 tests continue to pass


### PR DESCRIPTION
## Summary

Bootstraps the GitHub Issues workflow on itself — the first PR in the new process. Adds the process document, issue/PR templates, and a CLAUDE.md quick-reference. Also commits the approved design spec and implementation plans from today's design session.

## Changes

- `docs/GITHUB-WORKFLOW.md` — full workflow: issue titles, labels, branch naming, commit format, PR template, Claude Code session protocol; clarified branch naming pattern from `{type}/...` to `{branch-prefix}/...` with an explicit note that `feat` maps to `feature/` and commit messages use the shorter `feat:` token; updated commit rule to "type must match the issue type"
- `.github/ISSUE_TEMPLATE/feature.md` — issue body template (What / Why / Scope / Out of Scope / Acceptance Criteria / Related)
- `.github/pull_request_template.md` — PR template with `closes #N` mechanism
- `CLAUDE.md` — added Git Workflow section with quick reference; clarified that the Lombok restriction applies to hand-written JPA entities only (generated API models using Lombok via codegen are intentionally exempt)
- `docs/superpowers/specs/` and `docs/superpowers/plans/` — approved API docs + architecture docs design spec and implementation plans

## Test Evidence

- [ ] No code changes — documentation and config only
- [ ] `mvn compile` — no errors (no Java changed)

## Notes for Reviewer

After merging, create Issues 2 and 3 for the two implementation plans:
- Issue 2: `[feat] OpenAPI spec-first codegen, Phase 1 controller migration, and Swagger UI`
- Issue 3: `[docs] Architecture diagrams and ADRs`