### PR TITLE
docs: architecture diagrams and ADRs

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,237 @@
+# Advisor Platform — Architecture
+
+This document is the entry point for understanding the system. It contains the high-level context diagram, links to detailed sequence and flow diagrams, and links to Architecture Decision Records (ADRs).
+
+---
+
+## System Context
+
+```mermaid
+C4Context
+    title System Context — Advisor Platform
+
+    Person(visitor, "Visitor", "Website visitor seeking travel planning advice")
+    Person(advisor, "Advisor", "Travel advisor reviewing visitor inquiries")
+
+    System_Boundary(platform, "Advisor Platform") {
+        System(api, "Backend API", "Spring Boot 3.4 — handles AI chat, visitor identity, and advisor messaging")
+    }
+
+    System_Ext(anthropic, "Anthropic API", "Claude AI model — generates travel advice responses")
+    SystemDb_Ext(postgres, "PostgreSQL 16", "Stores visitors, AI sessions, messages, and threads")
+
+    Rel(visitor, api, "Identifies, chats with AI, sends advisor messages", "HTTPS/JSON + SSE")
+    Rel(advisor, api, "Reviews threads, replies to visitors", "HTTPS/JSON")
+    Rel(api, anthropic, "Streams AI completions", "HTTPS")
+    Rel(api, postgres, "Reads and writes data", "JDBC/Flyway")
+```
+
+---
+
+## Visitor Identity + Session Flow
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant API as Advisor Platform API
+    participant DB as PostgreSQL
+
+    Note over Browser,DB: Page load — visitor identification
+
+    Browser->>API: POST /api/v1/visitor/identify {browserToken}
+    API->>DB: SELECT * FROM visitor WHERE browser_token = ?
+    alt Visitor exists
+        DB-->>API: Visitor row
+        API->>DB: UPDATE visitor SET last_seen_at = now()
+    else New visitor
+        API->>DB: INSERT INTO visitor (browser_token)
+        DB-->>API: New Visitor row
+    end
+    API-->>Browser: {visitorId, browserToken}
+
+    Note over Browser,DB: Session creation
+
+    Browser->>API: POST /api/v1/session {visitorId}
+    API->>DB: SELECT * FROM visitor WHERE id = ?
+    DB-->>API: Visitor row
+    API->>DB: INSERT INTO ai_session (visitor_id)
+    DB-->>API: AiSession row
+    API-->>Browser: {sessionId, createdAt}
+
+    Note over Browser,DB: Non-streaming chat
+
+    Browser->>API: POST /api/v1/chat/{sessionId} {message}
+    API->>DB: SELECT * FROM ai_message WHERE session_id = ? ORDER BY created_at
+    DB-->>API: Message history
+    API->>DB: INSERT INTO ai_message (session_id, role='user', content)
+    API->>+Anthropic: Messages API call (history + new message)
+    Anthropic-->>-API: Assistant response
+    API->>DB: INSERT INTO ai_message (session_id, role='assistant', content, model, tokens)
+    API-->>Browser: {messageId, content, model, createdAt}
+```
+
+---
+
+## AI Streaming Pipeline
+
+```mermaid
+sequenceDiagram
+    participant Browser
+    participant API as Advisor Platform API
+    participant SpringAI as Spring AI (ChatModel)
+    participant Anthropic as Anthropic API
+    participant DB as PostgreSQL
+
+    Browser->>API: POST /api/v1/chat/{sessionId}/stream {message}
+    Note over API: SSE connection established (text/event-stream)
+
+    API->>DB: SELECT * FROM ai_message WHERE session_id = ? ORDER BY created_at
+    DB-->>API: Message history (up to maxHistoryTurns window)
+
+    API->>DB: INSERT INTO ai_message (role='user', content)
+    DB-->>API: Saved
+
+    API->>SpringAI: ChatModel.stream(systemPrompt + history + userMessage)
+    SpringAI->>Anthropic: POST /v1/messages (streaming: true)
+
+    loop Token stream
+        Anthropic-->>SpringAI: data: {delta: {text: "chunk"}}
+        SpringAI-->>API: Flux<ChatResponse> chunk
+        API-->>Browser: data: chunk\n\n
+    end
+
+    Anthropic-->>SpringAI: data: [DONE]
+    SpringAI-->>API: Flux complete (doOnComplete triggered)
+
+    API->>DB: INSERT INTO ai_message (role='assistant', full content, model, latency_ms)
+    Note over Browser: SSE connection closes
+```
+
+---
+
+## Message Threading Workflow
+
+> Dashed nodes indicate Phase 2 endpoints not yet implemented.
+
+```mermaid
+flowchart TD
+    A([Visitor submits initial message]) --> B
+
+    B["POST /api/v1/message\n─────────────────\nCreates MessageThread\nstatus = 'open'\nCreates ThreadMessage\nsenderRole = 'visitor'"]
+
+    B --> C{Advisor action}
+
+    C -->|View thread| D["GET /api/v1/thread/:id/messages\nReturns all messages"]
+    D --> C
+
+    C -->|Reply ➜ Phase 2| E["POST /api/v1/thread/:id/reply\nAdds ThreadMessage\nsenderRole = 'advisor'\nstatus → 'pending_reply'"]
+    E --> F{Visitor follow-up?}
+
+    F -->|Yes| G["POST /api/v1/thread/:id/messages\nAdds ThreadMessage\nsenderRole = 'visitor'\nstatus → 'open'"]
+    G --> C
+
+    F -->|No| C
+
+    C -->|Resolve ➜ Phase 2| H["PATCH /api/v1/thread/:id/status\nstatus = 'resolved'"]
+    C -->|Close ➜ Phase 2| I["PATCH /api/v1/thread/:id/status\nstatus = 'closed'"]
+
+    H --> J([Thread archived])
+    I --> J
+
+    style E stroke-dasharray: 5 5
+    style H stroke-dasharray: 5 5
+    style I stroke-dasharray: 5 5
+```
+
+---
+
+## Entity Relationships
+
+```mermaid
+erDiagram
+    VISITOR {
+        uuid id PK
+        varchar browser_token UK
+        varchar email UK
+        boolean email_verified
+        timestamptz tos_accepted_at
+        varchar tos_version
+        timestamptz created_at
+        timestamptz last_seen_at
+    }
+
+    AI_SESSION {
+        uuid id PK
+        uuid visitor_id FK
+        timestamptz created_at
+    }
+
+    AI_MESSAGE {
+        uuid id PK
+        uuid session_id FK
+        varchar role
+        text content
+        varchar model_version
+        int token_count
+        int latency_ms
+        timestamptz created_at
+    }
+
+    MESSAGE_THREAD {
+        uuid id PK
+        uuid visitor_id FK
+        uuid ai_session_id FK
+        varchar subject
+        varchar status
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    THREAD_MESSAGE {
+        uuid id PK
+        uuid thread_id FK
+        varchar sender_role
+        text content
+        timestamptz created_at
+    }
+
+    VISITOR ||--o{ AI_SESSION : "has"
+    AI_SESSION ||--o{ AI_MESSAGE : "contains"
+    VISITOR ||--o{ MESSAGE_THREAD : "owns"
+    AI_SESSION |o--o{ MESSAGE_THREAD : "optionally linked to"
+    MESSAGE_THREAD ||--o{ THREAD_MESSAGE : "contains"
+```
+
+---
+
+## Architecture Decision Records
+
+| ADR | Decision |
+|---|---|
+| [ADR-001](architecture/ADR-001-session-identity.md) | Session identity: browser token + find-or-create instead of authenticated users |
+| [ADR-002](architecture/ADR-002-ai-streaming.md) | AI streaming: SSE with post-stream persistence |
+| [ADR-003](architecture/ADR-003-message-threading.md) | Message threading: separate from AI sessions, visitor/advisor role model |
+
+---
+
+## Package Structure
+
+```
+src/main/java/com/advisorplatform/
+├── api/           ApiDelegate implementations (HTTP layer)
+├── service/       Business logic and orchestration
+├── domain/
+│   ├── entity/    JPA entities
+│   └── repository/ Spring Data repositories
+├── ai/            Spring AI + Anthropic integration
+└── config/        Spring configuration beans
+
+src/main/resources/api/   OpenAPI 3 spec files (one per domain, versioned)
+target/generated-sources/ Generated Spring interfaces + POJOs — do not edit
+```
+
+---
+
+## Maintenance
+
+When a PR changes the API surface or database schema, update the relevant diagram and/or ADR as part of the same PR.

--- a/docs/architecture/ADR-001-session-identity.md
+++ b/docs/architecture/ADR-001-session-identity.md
@@ -1,0 +1,34 @@
+# ADR-001: Session Identity — Browser Token + Find-or-Create
+
+**Status:** Accepted
+**Date:** 2026-04-01
+
+---
+
+## Context
+
+The platform needs to identify visitors across page loads without requiring account creation. Phase 1 targets first-time visitors who want to plan a trip immediately, without friction. Requiring email/password login upfront would reduce conversion.
+
+We also need to link AI chat sessions and message threads to a persistent visitor identity, so returning visitors can see their history.
+
+## Decision
+
+Use a randomly-generated browser token stored in `localStorage` as the visitor identity for Phase 1.
+
+On every page load, the frontend calls `POST /api/v1/visitor/identify` with the stored token. The backend does a find-or-create on the `visitor` table using `browser_token` as a unique key, updating `last_seen_at` on each visit.
+
+No password, no email, no session cookie — just a UUID in localStorage.
+
+## Consequences
+
+**Positive:**
+- Zero friction for new visitors — no sign-up required
+- Simple to implement and reason about
+- History persists across sessions on the same device/browser
+
+**Negative:**
+- Identity is lost if the user clears localStorage or switches browsers
+- No way to merge identities (e.g., same user on mobile and desktop)
+- No authentication — any client with a valid `visitorId` can access that visitor's data
+
+**Phase 2 plan:** Replace with Supabase-based auth (JWT verification in `infra/`). The `visitor` table already has `email` and `email_verified` columns for this transition. The `visitorId` in all requests will map to the authenticated user once auth is in place.

--- a/docs/architecture/ADR-002-ai-streaming.md
+++ b/docs/architecture/ADR-002-ai-streaming.md
@@ -1,0 +1,41 @@
+# ADR-002: AI Streaming — SSE with Post-Stream Persistence
+
+**Status:** Accepted
+**Date:** 2026-04-01
+
+---
+
+## Context
+
+The AI chat feature calls the Anthropic Claude API, which can take 5-30 seconds to generate a full response. Waiting for the full response before returning to the browser creates a poor user experience — the UI appears frozen.
+
+We need a streaming strategy that:
+1. Shows tokens to the user as they arrive
+2. Persists the full conversation turn to the database
+3. Maintains the conversation history for multi-turn context
+
+## Decision
+
+Use Server-Sent Events (SSE) for streaming. The `/api/v1/chat/{sessionId}/stream` endpoint returns `Content-Type: text/event-stream` and yields text tokens via a `Flux<String>` backed by Spring AI's `ChatModel.stream()`.
+
+**Persistence timing:**
+- The user message is persisted **before** the stream begins (so history is correct on retry)
+- The assistant message is persisted **after** the stream completes, using `Flux.doOnComplete()`
+- The full assistant content is accumulated in a `StringBuilder` during streaming
+
+**History loading:**
+- Message history is loaded **before** the user message is persisted to avoid the user's new message appearing twice in the context window (once in history, once as the final UserMessage)
+
+## Consequences
+
+**Positive:**
+- Perceived responsiveness is greatly improved — users see text immediately
+- Spring AI + Project Reactor (`Flux`) handle backpressure and cancellation natively
+- Simple implementation — no WebSocket, no custom SSE infrastructure
+
+**Negative:**
+- If the client disconnects mid-stream, `doOnComplete()` may not fire — the assistant message may not be persisted
+- Token count is unavailable during streaming (the Anthropic stream metadata arrives at the end); currently stored as 0 for stream responses
+- Non-streaming (`POST /api/v1/chat/{sessionId}`) is maintained as a fallback for testing and clients that don't support SSE
+
+**Future improvement:** Use `doOnNext()` + a final `doOnComplete()` callback with the accumulated tokens metadata if the Anthropic SDK exposes it in the stream completion event.

--- a/docs/architecture/ADR-003-message-threading.md
+++ b/docs/architecture/ADR-003-message-threading.md
@@ -1,0 +1,45 @@
+# ADR-003: Message Threading — Separate from AI Sessions
+
+**Status:** Accepted
+**Date:** 2026-04-01
+
+---
+
+## Context
+
+The platform has two distinct communication patterns:
+
+1. **AI Chat** — real-time, streaming, ephemeral. A visitor talks directly to Claude. Stored in `ai_session` / `ai_message`.
+2. **Advisor Messaging** — asynchronous, human-reviewed. A visitor sends a message to a human advisor and waits for a reply.
+
+These could have been modeled as a single "conversation" abstraction, or the advisor could have been added as a participant in the AI chat thread.
+
+## Decision
+
+Model advisor messaging as a completely separate entity hierarchy: `MessageThread` and `ThreadMessage`, independent of `AiSession` and `AiMessage`.
+
+A `MessageThread` has:
+- `visitorId` — the visitor who created it
+- `aiSessionId` (nullable) — an optional link to the AI session that prompted the inquiry
+- `subject` — a short description
+- `status` — state machine: `open` → `pending_reply` → `resolved` / `closed`
+
+A `ThreadMessage` has:
+- `senderRole` — either `"visitor"` or `"advisor"`
+- `content` — the message text
+
+## Consequences
+
+**Positive:**
+- Clean separation of concerns — AI chat and human messaging evolve independently
+- No risk of AI responses appearing in human advisor threads or vice versa
+- Status field enables advisor workflow (filter by `open`, sort by `updated_at`)
+- The nullable `aiSessionId` link allows context-passing ("I was talking to the AI about X, here is my follow-up question") without coupling the models
+
+**Negative:**
+- Two separate data models to maintain instead of one unified conversation model
+- Visitors cannot (currently) reference specific AI messages in their advisor thread — only the session as a whole
+
+**Alternatives considered:**
+- Unified conversation model: rejected because it would complicate the AI context window (advisor messages should not be sent to Claude) and the advisor inbox (AI messages should not appear there)
+- Adding advisor as an AI participant: rejected because it conflates human and AI roles in the same message stream

--- a/docs/architecture/diagrams/ai-streaming-pipeline.mmd
+++ b/docs/architecture/diagrams/ai-streaming-pipeline.mmd
@@ -1,0 +1,30 @@
+sequenceDiagram
+    participant Browser
+    participant API as Advisor Platform API
+    participant SpringAI as Spring AI (ChatModel)
+    participant Anthropic as Anthropic API
+    participant DB as PostgreSQL
+
+    Browser->>API: POST /api/v1/chat/{sessionId}/stream {message}
+    Note over API: SSE connection established (text/event-stream)
+
+    API->>DB: SELECT * FROM ai_message WHERE session_id = ? ORDER BY created_at
+    DB-->>API: Message history (up to maxHistoryTurns window)
+
+    API->>DB: INSERT INTO ai_message (role='user', content)
+    DB-->>API: Saved
+
+    API->>SpringAI: ChatModel.stream(systemPrompt + history + userMessage)
+    SpringAI->>Anthropic: POST /v1/messages (streaming: true)
+
+    loop Token stream
+        Anthropic-->>SpringAI: data: {delta: {text: "chunk"}}
+        SpringAI-->>API: Flux<ChatResponse> chunk
+        API-->>Browser: data: chunk\n\n
+    end
+
+    Anthropic-->>SpringAI: data: [DONE]
+    SpringAI-->>API: Flux complete (doOnComplete triggered)
+
+    API->>DB: INSERT INTO ai_message (role='assistant', full content, model, latency_ms)
+    Note over Browser: SSE connection closes

--- a/docs/architecture/diagrams/c4-context.mmd
+++ b/docs/architecture/diagrams/c4-context.mmd
@@ -1,0 +1,17 @@
+C4Context
+    title System Context — Advisor Platform
+
+    Person(visitor, "Visitor", "Website visitor seeking travel planning advice")
+    Person(advisor, "Advisor", "Travel advisor reviewing visitor inquiries")
+
+    System_Boundary(platform, "Advisor Platform") {
+        System(api, "Backend API", "Spring Boot 3.4 — handles AI chat, visitor identity, and advisor messaging")
+    }
+
+    System_Ext(anthropic, "Anthropic API", "Claude AI model — generates travel advice responses")
+    SystemDb_Ext(postgres, "PostgreSQL 16", "Stores visitors, AI sessions, messages, and threads")
+
+    Rel(visitor, api, "Identifies, chats with AI, sends advisor messages", "HTTPS/JSON + SSE")
+    Rel(advisor, api, "Reviews threads, replies to visitors", "HTTPS/JSON")
+    Rel(api, anthropic, "Streams AI completions", "HTTPS")
+    Rel(api, postgres, "Reads and writes data", "JDBC/Flyway")

--- a/docs/architecture/diagrams/entity-relationships.mmd
+++ b/docs/architecture/diagrams/entity-relationships.mmd
@@ -1,0 +1,52 @@
+erDiagram
+    VISITOR {
+        uuid id PK
+        varchar browser_token UK
+        varchar email UK
+        boolean email_verified
+        timestamptz tos_accepted_at
+        varchar tos_version
+        timestamptz created_at
+        timestamptz last_seen_at
+    }
+
+    AI_SESSION {
+        uuid id PK
+        uuid visitor_id FK
+        timestamptz created_at
+    }
+
+    AI_MESSAGE {
+        uuid id PK
+        uuid session_id FK
+        varchar role
+        text content
+        varchar model_version
+        int token_count
+        int latency_ms
+        timestamptz created_at
+    }
+
+    MESSAGE_THREAD {
+        uuid id PK
+        uuid visitor_id FK
+        uuid ai_session_id FK
+        varchar subject
+        varchar status
+        timestamptz created_at
+        timestamptz updated_at
+    }
+
+    THREAD_MESSAGE {
+        uuid id PK
+        uuid thread_id FK
+        varchar sender_role
+        text content
+        timestamptz created_at
+    }
+
+    VISITOR ||--o{ AI_SESSION : "has"
+    AI_SESSION ||--o{ AI_MESSAGE : "contains"
+    VISITOR ||--o{ MESSAGE_THREAD : "owns"
+    AI_SESSION |o--o{ MESSAGE_THREAD : "optionally linked to"
+    MESSAGE_THREAD ||--o{ THREAD_MESSAGE : "contains"

--- a/docs/architecture/diagrams/message-threading-workflow.mmd
+++ b/docs/architecture/diagrams/message-threading-workflow.mmd
@@ -1,0 +1,27 @@
+flowchart TD
+    A([Visitor submits initial message]) --> B
+
+    B["POST /api/v1/message\n─────────────────\nCreates MessageThread\nstatus = 'open'\nCreates ThreadMessage\nsenderRole = 'visitor'"]
+
+    B --> C{Advisor action}
+
+    C -->|View thread| D["GET /api/v1/thread/:id/messages\nReturns all messages"]
+    D --> C
+
+    C -->|Reply ➜ Phase 2| E["POST /api/v1/thread/:id/reply\nAdds ThreadMessage\nsenderRole = 'advisor'\nstatus → 'pending_reply'"]
+    E --> F{Visitor follow-up?}
+
+    F -->|Yes| G["POST /api/v1/thread/:id/messages\nAdds ThreadMessage\nsenderRole = 'visitor'\nstatus → 'open'"]
+    G --> C
+
+    F -->|No| C
+
+    C -->|Resolve ➜ Phase 2| H["PATCH /api/v1/thread/:id/status\nstatus = 'resolved'"]
+    C -->|Close ➜ Phase 2| I["PATCH /api/v1/thread/:id/status\nstatus = 'closed'"]
+
+    H --> J([Thread archived])
+    I --> J
+
+    style E stroke-dasharray: 5 5
+    style H stroke-dasharray: 5 5
+    style I stroke-dasharray: 5 5

--- a/docs/architecture/diagrams/visitor-session-flow.mmd
+++ b/docs/architecture/diagrams/visitor-session-flow.mmd
@@ -1,0 +1,37 @@
+sequenceDiagram
+    participant Browser
+    participant API as Advisor Platform API
+    participant DB as PostgreSQL
+
+    Note over Browser,DB: Page load — visitor identification
+
+    Browser->>API: POST /api/v1/visitor/identify {browserToken}
+    API->>DB: SELECT * FROM visitor WHERE browser_token = ?
+    alt Visitor exists
+        DB-->>API: Visitor row
+        API->>DB: UPDATE visitor SET last_seen_at = now()
+    else New visitor
+        API->>DB: INSERT INTO visitor (browser_token)
+        DB-->>API: New Visitor row
+    end
+    API-->>Browser: {visitorId, browserToken}
+
+    Note over Browser,DB: Session creation
+
+    Browser->>API: POST /api/v1/session {visitorId}
+    API->>DB: SELECT * FROM visitor WHERE id = ?
+    DB-->>API: Visitor row
+    API->>DB: INSERT INTO ai_session (visitor_id)
+    DB-->>API: AiSession row
+    API-->>Browser: {sessionId, createdAt}
+
+    Note over Browser,DB: Non-streaming chat
+
+    Browser->>API: POST /api/v1/chat/{sessionId} {message}
+    API->>DB: SELECT * FROM ai_message WHERE session_id = ? ORDER BY created_at
+    DB-->>API: Message history
+    API->>DB: INSERT INTO ai_message (session_id, role='user', content)
+    API->>+Anthropic: Messages API call (history + new message)
+    Anthropic-->>-API: Assistant response
+    API->>DB: INSERT INTO ai_message (session_id, role='assistant', content, model, tokens)
+    API-->>Browser: {messageId, content, model, createdAt}


### PR DESCRIPTION
## Summary

- `docs/ARCHITECTURE.md` — entry point with all 5 Mermaid diagrams inline (renders natively on GitHub), ADR index, package structure, and maintenance guidance
- `docs/architecture/diagrams/` — standalone `.mmd` source files for editor tooling
- **ADR-001** — browser token find-or-create identity; Phase 2 Supabase auth migration path
- **ADR-002** — SSE streaming with pre-stream user message persistence and post-stream assistant message persistence via `doOnComplete()`
- **ADR-003** — separate `MessageThread`/`ThreadMessage` hierarchy from AI sessions, with rationale for rejecting a unified conversation model

## Test Plan

- [ ] Open `docs/ARCHITECTURE.md` on GitHub and verify all 5 Mermaid diagrams render correctly
- [ ] Check ADR links in the table resolve to the correct files

closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)